### PR TITLE
Add GitHub Actions CI/CD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      bun-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/scripts"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,84 @@
+name: "Build"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    name: check, lint & test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install just
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
+
+      - name: Type-check & lint (tsc + biome)
+        run: just check
+
+      - name: Run tests with coverage
+        run: |
+          just test-coverage | tee coverage.txt
+          PERCENT=$(grep "All files" coverage.txt | awk -F'|' '{gsub(/ /,"",$3); print $3}')
+          echo "COVERAGE=$PERCENT" >> "$GITHUB_ENV"
+
+      - name: Update test coverage badge
+        if: github.event_name == 'push'
+        uses: schneegans/dynamic-badges-action@v1.8.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: b345b1863b0bfcb30cd59856253a9227
+          filename: coverage.json
+          label: coverage
+          message: ${{ env.COVERAGE }}%
+          minColorRange: 50
+          maxColorRange: 90
+          valColorRange: ${{ env.COVERAGE }}
+
+  docker-startup-check:
+    name: Docker startup check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install just
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
+
+      - name: Build and start the app
+        run: just up
+
+      - name: Wait for all containers to be healthy
+        run: |
+          tries=0
+          max=24
+          while [ "$(docker ps --filter health=starting --format '{{.ID}}' | wc -l)" -gt 0 ]; do
+            tries=$((tries+1))
+            if [ "$tries" -ge "$max" ]; then
+              echo "Timed out waiting for healthy containers" >&2
+              docker ps
+              exit 1
+            fi
+            sleep 5
+          done
+          unhealthy=$(docker ps --filter 'health=unhealthy' -q)
+          if [ -n "$unhealthy" ]; then
+            echo "Unhealthy containers detected!" >&2
+            docker ps
+            exit 1
+          fi
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Tear down containers
+        run: just down

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,55 @@
+name: "Release & Deploy"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Release with semantic-release
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-release-${{ github.ref_name }}
+      cancel-in-progress: false
+
+    permissions:
+      contents: write
+
+    env:
+      GIT_COMMITTER_NAME: "github-actions"
+      GIT_COMMITTER_EMAIL: "actions@users.noreply.github.com"
+      GIT_AUTHOR_NAME: "github-actions"
+      GIT_AUTHOR_EMAIL: "actions@users.noreply.github.com"
+
+    steps:
+      - name: Setup | Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Action | Semantic Version Release
+        id: release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy on VPS
+    needs: release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          port: ${{ secrets.VPS_PORT }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            bash "${{ secrets.DEPLOY_SCRIPT_PATH }}"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,18 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    ["@semantic-release/npm", { "npmPublish": false }],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "CHANGELOG.md"],
+        "message": "chore(release): v${nextRelease.version}\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # 🐶 Shooting Stars Meme Generator
 
 ![Version](https://img.shields.io/github/package-json/v/TeKrop/shooting-stars-meme-generator)
+[![Build Status](https://github.com/TeKrop/shooting-stars-meme-generator/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/TeKrop/shooting-stars-meme-generator/actions/workflows/build.yml)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/TeKrop/b345b1863b0bfcb30cd59856253a9227/raw/coverage.json)
 [![Issues](https://img.shields.io/github/issues/TeKrop/shooting-stars-meme-generator)](https://github.com/TeKrop/shooting-stars-meme-generator/issues)
-[![License: MIT](https://img.shields.io/github/license/TeKrop/shooting-stars-meme-generator)](https://github.com/TeKrop/shooting-stars-meme-generator/blob/master/LICENSE)
+[![License: MIT](https://img.shields.io/github/license/TeKrop/shooting-stars-meme-generator)](https://github.com/TeKrop/shooting-stars-meme-generator/blob/main/LICENSE)
 
 ![Shootings Star Meme Generator](https://files.tekrop.fr/shooting-stars.jpg)
 
@@ -74,7 +76,7 @@ Feel free to check [issues page](https://github.com/TeKrop/shooting-stars-meme-g
 
 Copyright © 2017-2026 [Valentin PORCHET](https://github.com/TeKrop).
 
-This project is [MIT](https://github.com/TeKrop/shooting-stars-meme-generator/blob/master/LICENSE) licensed.
+This project is [MIT](https://github.com/TeKrop/shooting-stars-meme-generator/blob/main/LICENSE) licensed.
 
 ***
 _This README was generated with ❤️ by [readme-md-generator](https://github.com/kefranabg/readme-md-generator)_

--- a/justfile
+++ b/justfile
@@ -46,6 +46,11 @@ test:
     @echo "Running tests..."
     {{ docker_compose }} --profile dev run --rm bun-dev bun test
 
+# run the test suite with a coverage report (text)
+test-coverage:
+    @echo "Running tests with coverage..."
+    {{ docker_compose }} --profile dev run --rm bun-dev bun test --coverage
+
 # build & run Shooting Stars application (production mode)
 up: build start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "shooting-stars",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "description": "Shooting Stars Meme Generator",
     "main": "server/server.ts",
     "scripts": {


### PR DESCRIPTION
## Summary
- `build.yml`: `just check` (tsc + biome) and `just test-coverage` (bun test --coverage), updating a coverage badge via a gist; separate `docker-startup-check` job runs `just up`, waits for container health, `just down`.
- `release.yaml`: semantic-release (conventional commits) bumps `package.json`, generates a changelog, cuts a GitHub Release, then deploys to the VPS over SSH.
- `.github/dependabot.yml`: weekly updates for `bun`, the two `docker` images (root + `scripts/`), and `github-actions`.
- `package.json` bumped to `2.0.0` as the baseline for the first automated release (Bun rewrite milestone) — a `v2.0.0` tag will be pushed on the merge commit separately.
- README: added build-status and coverage badges, fixed the stale `blob/master/LICENSE` link to `main`.

Mirrors the CI/CD pattern already used in `overfast-api`/`overgraphql-api`, adapted for this repo's Docker/`just`-only workflow (no bare `bun`/`setup-bun` step — everything in `build.yml` goes through `just`, same as local dev).

**Not included** (can't be done via code): installing the GitGuardian and Sourcery AI GitHub Apps on this repo — that's a manual step via the GitHub Marketplace / each tool's dashboard.

## Setup required before this is fully live
- [x] Add repo secrets: `GIST_SECRET` (PAT with `gist` scope), `VPS_HOST`, `VPS_PORT`, `VPS_USER`, `VPS_SSH_KEY`, `DEPLOY_SCRIPT_PATH`
- [x] Settings → Actions → General → Workflow permissions → "Read and write permissions" (so `@semantic-release/git` can push the version-bump commit)
- [x] Install GitGuardian and Sourcery AI GitHub Apps on this repo
- [ ] After merge: push a `v2.0.0` tag on the merge commit to bootstrap semantic-release

## Test plan
- [x] `just check` passes locally
- [x] `just test-coverage` runs and produces the expected "All files" summary row the CI parsing relies on
- [x] New YAML/JSON files validated for syntax
- [x] Watch `build.yml`'s two jobs go green on this PR