### PR TITLE
Fix coverage badge: capture bun test's stderr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          just test-coverage | tee coverage.txt
+          just test-coverage 2>&1 | tee coverage.txt
           PERCENT=$(grep "All files" coverage.txt | awk -F'|' '{gsub(/ /,"",$3); print $3}')
           echo "COVERAGE=$PERCENT" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
`bun test`'s coverage table (and all test output) goes to stderr, not stdout — `just test-coverage | tee coverage.txt` in build.yml only piped stdout, so `coverage.txt` never had the "All files" line the CI parsing greps for. Confirmed on the first `build.yml` run on `main`: it pushed `{"message":"%"}` (empty percentage) to the coverage gist.

Fix: `just test-coverage 2>&1 | tee coverage.txt`.

## Test plan
- [x] Reproduced locally: stdout alone has no "All files" line, stderr does
- [x] Verified `2>&1 | tee` + the existing grep/awk parses `94.64` correctly
- [ ] Watch this PR's `build.yml` run and confirm the gist gets a real percentage this time

## Summary by Sourcery

CI:
- Update build workflow to pipe bun test stderr into coverage.txt to restore accurate coverage percentage extraction.