### PR TITLE
docs: document contributing workflow and conventional commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,3 +142,20 @@ project-level config (`Dockerfile`, `docker-compose.yml`, `justfile`,
 - The upload filter only checks MIME type (`image/*`), not file contents or extension.
 - The app always listens on `9595`; only the Docker host-side publish port (`APP_PORT` env var) can differ, and in the current compose setup is bound to localhost only.
 - Uploaded files older than `UPLOAD_RETENTION_DAYS` (default 30) are deleted daily by the `cleanup` compose service — see `scripts/` in Architecture above.
+
+## Contributing
+
+Commit messages **must** follow [Conventional Commits](https://www.conventionalcommits.org/)
+(`type(scope): subject`, e.g. `fix: correct upload hash length`) — this isn't
+just style. `.releaserc.json` runs `semantic-release` with the default
+`@semantic-release/commit-analyzer` (Angular preset) on every push to `main`
+via `.github/workflows/release.yaml`: it parses commit types to decide
+whether to cut a release and what version bump to apply (`fix:` → patch,
+`feat:` → minor, `BREAKING CHANGE:` footer or `!` → major, other types like
+`chore:`/`docs:`/`refactor:` → no release), then generates `CHANGELOG.md`
+entries from those same messages. A non-conventional commit message is
+silently ignored by the analyzer rather than erroring, so the practical
+failure mode is a change landing with no version bump/changelog entry, not
+a build break. Before opening a PR, run `just check`/`just test` locally
+(see Commands above) — CI (`.github/workflows/build.yml`) runs the same
+checks.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Contributions, issues and feature requests are welcome!
 
 Feel free to check [issues page](https://github.com/TeKrop/shooting-stars-meme-generator/issues).
 
+Before opening a PR:
+* run `just check` (type-check + lint) and `just test` locally — CI runs the same checks on every PR
+* write commit messages following [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): subject`, e.g. `fix: correct upload hash length`, `feat: add drag-and-drop upload`). This isn't just style: releases are automated with [semantic-release](https://semantic-release.gitbook.io/), which parses commit types to decide the version bump and to generate `CHANGELOG.md` — a non-conventional commit message won't break the build, but it'll be silently skipped when the changelog/version are generated.
+
 ## 📝 License
 
 Copyright © 2017-2026 [Valentin PORCHET](https://github.com/TeKrop).

--- a/README.md
+++ b/README.md
@@ -73,8 +73,12 @@ Contributions, issues and feature requests are welcome!
 Feel free to check [issues page](https://github.com/TeKrop/shooting-stars-meme-generator/issues).
 
 Before opening a PR:
+
+**Local checks**
 * run `just check` (type-check + lint) and `just test` locally — CI runs the same checks on every PR
-* write commit messages following [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): subject`, e.g. `fix: correct upload hash length`, `feat: add drag-and-drop upload`). This isn't just style: releases are automated with [semantic-release](https://semantic-release.gitbook.io/), which parses commit types to decide the version bump and to generate `CHANGELOG.md` — a non-conventional commit message won't break the build, but it'll be silently skipped when the changelog/version are generated.
+
+**Commit messages**
+* follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): subject`, e.g. `fix: correct upload hash length`, `feat: add drag-and-drop upload`) — this drives automated releases, see [CLAUDE.md § Contributing](CLAUDE.md#contributing) for details
 
 ## 📝 License
 


### PR DESCRIPTION
## Summary
- Document in README.md and CLAUDE.md that commit messages must follow Conventional Commits, and why: `semantic-release`'s `commit-analyzer` (Angular preset) already relies on it in production to decide version bumps and generate `CHANGELOG.md` (`.releaserc.json`, `.github/workflows/release.yaml`)
- Note that a non-conventional commit doesn't break CI, it's just silently skipped by the changelog/version bump
- Point contributors at `just check`/`just test` before opening a PR (same checks CI runs in `.github/workflows/build.yml`)

## Test plan
- [x] Docs-only change, no code affected

## Summary by Sourcery

Clarify the contributing workflow by documenting required Conventional Commit messages and local pre-PR checks.

Documentation:
- Add contributing guidelines in CLAUDE.md explaining the use of Conventional Commits and how they drive automated releases and changelog generation.
- Update README.md contributing section to require Conventional Commit messages and running local `just check`/`just test` before opening pull requests.