### PR TITLE
style: modernize CTA buttons, tighten title, fix lint warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ it isn't wired into `just build`/`just dev` automatically.
 ## Linting/formatting
 
 Biome (`biome.json`) replaces the usual ESLint+Prettier pair — one tool,
-one config, no plugins needed for a project this size. Two deliberate rule
+one config, no plugins needed for a project this size. Three deliberate rule
 overrides on top of the recommended preset:
 - `style/noNonNullAssertion` off — `client/script.ts` leans on `!`/`as` casts
   for DOM lookups of elements that are always present (see Architecture
@@ -91,6 +91,14 @@ overrides on top of the recommended preset:
 - `a11y/useMediaCaption` off — the one `<video>` in `index.html` is a silent
   decorative background loop with no dialogue, so a captions requirement
   doesn't apply.
+- `style/noDescendingSpecificity` off — `client/style.css` mixes a handful of
+  ID selectors (`#tap-to-play`, `#preview-confirm`, etc.) with the rest of
+  the sheet's class selectors; the rule compares specificity file-wide, so
+  any later `&:hover`/`&:active`/`&[hidden]` on an unrelated class selector
+  gets flagged against an earlier ID selector's pseudo-class even though
+  they target completely different elements and never actually collide in
+  the cascade. All 12 warnings it raised were this false-positive shape, not
+  real ordering bugs.
 
 CSS formatting/linting is enabled (default), which reformats `client/style.css`'s
 `@keyframes` rules from compact one-liners into one-property-per-line —

--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,8 @@
         "rules": {
             "preset": "recommended",
             "style": {
-                "noNonNullAssertion": "off"
+                "noNonNullAssertion": "off",
+                "noDescendingSpecificity": "off"
             },
             "a11y": {
                 "useMediaCaption": "off"

--- a/client/index.html
+++ b/client/index.html
@@ -20,7 +20,7 @@
         </video>
         <header class="site-title">
             <img src="./public/img/favicon.png" alt="" class="site-logo">
-            <h1>Shooting Stars Meme Generator</h1>
+            <h1>Shooting Stars<br>Meme Generator</h1>
         </header>
         <div class="uploader">
             <div class="uploader-card">

--- a/client/style.css
+++ b/client/style.css
@@ -23,24 +23,25 @@ body {
     left: 50%;
 
     transform: translate(-50%, -50%);
-    border: 3px solid var(--color-cyan);
-    border-radius: 12px;
-    padding: 20px 32px;
-    background: rgba(17, 17, 22, 0.55);
+    border: 1.5px solid rgba(243, 156, 18, 0.5);
+    border-radius: 999px;
+    padding: 22px 44px;
+    background: rgba(17, 17, 22, 0.6);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
     box-shadow:
-        4px 4px 0 var(--color-ink),
-        0 0 16px rgba(46, 230, 214, 0.3);
-    animation: pulse-glow 1.8s ease-in-out infinite;
+        0 12px 32px rgba(0, 0, 0, 0.45),
+        0 0 24px rgba(243, 156, 18, 0.18);
+    animation: pulse-glow 2.4s ease-in-out infinite;
     cursor: pointer;
     opacity: 1;
     transition:
         opacity 0.4s ease,
-        transform 0.15s ease,
-        box-shadow 0.15s ease,
-        background 0.2s ease,
-        color 0.2s ease,
-        border-color 0.2s ease,
-        filter 0.15s ease;
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        background 0.25s ease,
+        color 0.25s ease,
+        border-color 0.25s ease;
 
     color: var(--color-cream);
     font-family: sans-serif;
@@ -81,29 +82,29 @@ body {
         animation-play-state: paused;
     }
 
-    /* solid cyan fill + black text + white border is an unmissable
-       "you're hovering this" signal on top of the scale — .spark inherits
-       `color` from here too, so the sparkles flip to ink along with the text */
+    /* gradient fill + ink text is the "you're hovering this" signal on top
+       of the scale — .spark inherits `color` from here too, so the sparkles
+       flip to ink along with the text */
     &:hover {
-        background: var(--color-cyan);
+        background: linear-gradient(135deg, #f9b13a, #f39c12);
         color: var(--color-ink);
-        border-color: white;
-        transform: translate(-50%, -50%) scale(1.05);
+        border-color: rgba(243, 156, 18, 0.9);
+        transform: translate(-50%, -50%) scale(1.03);
         box-shadow:
-            6px 6px 0 var(--color-ink),
-            0 0 32px rgba(46, 230, 214, 0.6);
+            0 16px 40px rgba(0, 0, 0, 0.5),
+            0 0 36px rgba(243, 156, 18, 0.4);
     }
 
     &:active {
-        transform: translate(-50%, -50%) scale(0.96);
-        box-shadow: 0 0 0 var(--color-ink);
-        filter: brightness(0.9);
+        transform: translate(-50%, -50%) scale(0.97);
+        box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+        filter: brightness(0.95);
     }
 
     &:focus-visible {
-        outline: 3px solid var(--color-cyan);
+        outline: 2px solid var(--color-orange);
         outline-offset: 4px;
-        transform: translate(-50%, -50%) scale(1.05);
+        transform: translate(-50%, -50%) scale(1.03);
     }
 }
 
@@ -111,13 +112,13 @@ body {
     0%,
     100% {
         box-shadow:
-            4px 4px 0 var(--color-ink),
-            0 0 16px rgba(46, 230, 214, 0.3);
+            0 12px 32px rgba(0, 0, 0, 0.45),
+            0 0 24px rgba(243, 156, 18, 0.18);
     }
     50% {
         box-shadow:
-            4px 4px 0 var(--color-ink),
-            0 0 30px rgba(46, 230, 214, 0.65);
+            0 12px 32px rgba(0, 0, 0, 0.45),
+            0 0 40px rgba(243, 156, 18, 0.4);
     }
 }
 
@@ -222,7 +223,7 @@ div#pictures-container {
 
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 6px;
     max-width: 280px;
 }
 
@@ -518,14 +519,27 @@ dialog#preview-dialog {
         background: #4a4f57;
     }
 
-    /* the final, primary action — bigger, distinct color, and a gentle
-       pulse so it's unmistakably the one to press */
+    /* the final, primary action — same soft-glow pill treatment as
+       #tap-to-play, so it's unmistakably the one to press without
+       resorting to the flashy cyan the rest of the dialog avoids */
     #preview-confirm {
         font-size: 18px;
-        padding: 12px 22px;
-        background: var(--color-cyan);
+        padding: 14px 28px;
+        border: 1.5px solid rgba(243, 156, 18, 0.6);
+        border-radius: 999px;
+        background: linear-gradient(135deg, #f9b13a, #f39c12);
         color: var(--color-ink);
-        animation: pulse-button 2s ease-in-out infinite;
+        box-shadow: 0 10px 28px rgba(243, 156, 18, 0.35);
+        animation: pulse-button 2.2s ease-in-out infinite;
+
+        &:hover {
+            box-shadow: 0 14px 36px rgba(243, 156, 18, 0.55);
+        }
+
+        &:active {
+            transform: scale(0.96);
+            box-shadow: 0 6px 16px rgba(243, 156, 18, 0.3);
+        }
 
         &:disabled {
             animation: none;

--- a/client/style.css
+++ b/client/style.css
@@ -3,6 +3,8 @@
     --color-ink: #111116;
     --color-cream: #fff8ec;
     --color-orange: #f39c12;
+    --color-orange-rgb: 243, 156, 18;
+    --color-orange-light: #f9b13a;
     --color-cyan: #2ee6d6;
 }
 
@@ -23,7 +25,7 @@ body {
     left: 50%;
 
     transform: translate(-50%, -50%);
-    border: 1.5px solid rgba(243, 156, 18, 0.5);
+    border: 1.5px solid rgba(var(--color-orange-rgb), 0.5);
     border-radius: 999px;
     padding: 22px 44px;
     background: rgba(17, 17, 22, 0.6);
@@ -31,7 +33,7 @@ body {
     -webkit-backdrop-filter: blur(14px);
     box-shadow:
         0 12px 32px rgba(0, 0, 0, 0.45),
-        0 0 24px rgba(243, 156, 18, 0.18);
+        0 0 24px rgba(var(--color-orange-rgb), 0.18);
     animation: pulse-glow 2.4s ease-in-out infinite;
     cursor: pointer;
     opacity: 1;
@@ -86,13 +88,17 @@ body {
        of the scale — .spark inherits `color` from here too, so the sparkles
        flip to ink along with the text */
     &:hover {
-        background: linear-gradient(135deg, #f9b13a, #f39c12);
+        background: linear-gradient(
+            135deg,
+            var(--color-orange-light),
+            var(--color-orange)
+        );
         color: var(--color-ink);
-        border-color: rgba(243, 156, 18, 0.9);
+        border-color: rgba(var(--color-orange-rgb), 0.9);
         transform: translate(-50%, -50%) scale(1.03);
         box-shadow:
             0 16px 40px rgba(0, 0, 0, 0.5),
-            0 0 36px rgba(243, 156, 18, 0.4);
+            0 0 36px rgba(var(--color-orange-rgb), 0.4);
     }
 
     &:active {
@@ -101,10 +107,11 @@ body {
         filter: brightness(0.95);
     }
 
+    /* no scale here (unlike :hover/:active) — keyboard focus shouldn't
+       shift the button's position, just call it out with the outline */
     &:focus-visible {
         outline: 2px solid var(--color-orange);
         outline-offset: 4px;
-        transform: translate(-50%, -50%) scale(1.03);
     }
 }
 
@@ -113,12 +120,12 @@ body {
     100% {
         box-shadow:
             0 12px 32px rgba(0, 0, 0, 0.45),
-            0 0 24px rgba(243, 156, 18, 0.18);
+            0 0 24px rgba(var(--color-orange-rgb), 0.18);
     }
     50% {
         box-shadow:
             0 12px 32px rgba(0, 0, 0, 0.45),
-            0 0 40px rgba(243, 156, 18, 0.4);
+            0 0 40px rgba(var(--color-orange-rgb), 0.4);
     }
 }
 
@@ -525,20 +532,24 @@ dialog#preview-dialog {
     #preview-confirm {
         font-size: 18px;
         padding: 14px 28px;
-        border: 1.5px solid rgba(243, 156, 18, 0.6);
+        border: 1.5px solid rgba(var(--color-orange-rgb), 0.6);
         border-radius: 999px;
-        background: linear-gradient(135deg, #f9b13a, #f39c12);
+        background: linear-gradient(
+            135deg,
+            var(--color-orange-light),
+            var(--color-orange)
+        );
         color: var(--color-ink);
-        box-shadow: 0 10px 28px rgba(243, 156, 18, 0.35);
+        box-shadow: 0 10px 28px rgba(var(--color-orange-rgb), 0.35);
         animation: pulse-button 2.2s ease-in-out infinite;
 
         &:hover {
-            box-shadow: 0 14px 36px rgba(243, 156, 18, 0.55);
+            box-shadow: 0 14px 36px rgba(var(--color-orange-rgb), 0.55);
         }
 
         &:active {
             transform: scale(0.96);
-            box-shadow: 0 6px 16px rgba(243, 156, 18, 0.3);
+            box-shadow: 0 6px 16px rgba(var(--color-orange-rgb), 0.3);
         }
 
         &:disabled {


### PR DESCRIPTION
## Summary
- Rework `#tap-to-play` and the upload-step confirm button from the flashy cyan neon look to a softer glass-pill style (blurred dark fill, warm orange glow/border, gradient fill on hover), per design feedback that the cyan was too flashy and the main CTA needed a more modern style.
- Tighten the gap between the top-right logo and title (10px → 6px), and force the title onto two explicit lines ("Shooting Stars" / "Meme Generator") instead of relying on text wrap.
- Disable `style/noDescendingSpecificity` in Biome — it was flagging false positives between unrelated ID and class selectors (e.g. `#tap-to-play:hover` vs `footer a:hover`) that never actually collide in the cascade. Documented in CLAUDE.md alongside the other deliberate rule overrides.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bunx biome check .` passes clean (no warnings)
- [x] Verified visually in a running dev container: tap-to-play button (idle/hover/focus), upload-preview-dialog confirm button (idle/hover), and top-right title layout

## Summary by Sourcery

Modernize the primary CTA visuals and title layout while aligning lint configuration with current CSS usage.

Enhancements:
- Restyle the tap-to-play CTA and preview dialog confirm button with a softer glass-pill treatment, warm orange glow, and updated hover/active states.
- Adjust the header layout by tightening spacing between the logo and title and explicitly splitting the title into two lines for more controlled typography.

Build:
- Update Biome configuration behavior by disabling the style/noDescendingSpecificity rule to avoid false-positive warnings in the stylesheet.

Documentation:
- Document the additional Biome lint rule override for CSS descending specificity in CLAUDE.md.