### PR TITLE
fix: scale shooting-stars animation and mobile layout to viewport

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -163,16 +163,26 @@ div#pictures-container {
        of (and blocks clicks/hover on) #tap-to-play in the stacking order,
        since it comes later in the DOM and neither has a z-index */
     pointer-events: none;
+    /* keyframe translate()/scale() distances below are tuned in px for
+       desktop widths; this scales the whole rendered transform down
+       proportionally on narrow viewports so travel stays on-screen and
+       doesn't read as faster than on desktop */
+    --travel-scale: clamp(0.25, calc(100vw / 1400px), 1);
 
     img {
         position: absolute;
-        max-width: 30%;
-        max-height: 30%;
+        /* box grown by the inverse of --travel-scale so the `scale`
+           below cancels it out at rest — the image stays the same
+           fraction of the viewport as on desktop, only the travel
+           distance actually shrinks */
+        max-width: calc(30% / var(--travel-scale));
+        max-height: calc(30% / var(--travel-scale));
         top: 0;
         left: 0;
         right: 0;
         bottom: 0;
         margin: auto;
+        scale: var(--travel-scale);
 
         &.hide {
             display: none;
@@ -703,15 +713,41 @@ footer {
     }
 
     #tap-to-play {
-        max-width: 90vw;
+        box-sizing: border-box;
+        width: 92vw;
         font-size: 2.2em;
         padding: 14px 20px;
     }
 
     footer {
+        box-sizing: border-box;
+        width: 92vw;
         font-size: 11px;
         padding: 5px 12px;
         bottom: 8px;
+    }
+}
+
+@media (orientation: portrait) {
+    .site-title {
+        top: max(20px, 2.5vh);
+        max-width: 44vw;
+    }
+
+    .uploader {
+        top: max(20px, 2.5vh);
+        max-width: 42vw;
+    }
+
+    #tap-to-play {
+        font-size: clamp(1.6em, 5.5vh, 2.6em);
+        padding: clamp(18px, 3vh, 26px) clamp(28px, 6vw, 44px);
+    }
+
+    footer {
+        bottom: max(16px, 3vh);
+        font-size: clamp(12px, 3vw, 14px);
+        padding: 8px 18px;
     }
 }
 


### PR DESCRIPTION
## Summary
- Animation `translate()` distances were hardcoded in px, tuned for desktop widths — on phones they crossed the whole screen almost instantly and mostly traveled off-screen. Added a viewport-based `scale` factor (`clamp(0.25, calc(100vw / 1400px), 1)`) that shrinks travel distance proportionally on narrow viewports, with a compensating inverse on the image's `max-width`/`max-height` so pictures don't end up looking smaller than on desktop.
- Added a `@media (orientation: portrait)` block giving the site title, uploader card, tap-to-play button, and footer viewport-relative sizing instead of a flat desktop-shrunk layout.
- Stretched the tap-to-play button and footer to `width: 92vw` on phones (`max-width: 480px` breakpoint) so they fill most of the available width instead of shrink-wrapping to content.
- Desktop (≥1400px wide) is unaffected — `scale` resolves to exactly `1` and all existing rules are untouched.

## Test plan
- [x] `just check` (tsc --noEmit + biome check) passes
- [x] `just test` (bun test, 12/12) passes
- [x] Verified in Chrome at 1920×1080 (desktop, unchanged), 390×844 and 768×1024 (portrait phone/tablet), and 844×390 (landscape) via computed-style checks: `scale`, image render size, button/footer width all match expected values at each breakpoint

## Summary by Sourcery

Improve mobile viewport behavior by making the shooting-stars animation and key UI elements (title, uploader card, tap-to-play button, footer) scale and position responsively, without affecting the desktop experience.

Bug Fixes:
- Scale shooting-star animation travel distance to viewport width so motion remains on-screen and consistent across desktop and mobile.

Enhancements:
- Adjust picture sizing via inverse scaling so images retain consistent relative size while animation travel is reduced on small viewports.
- Update tap-to-play button and footer to use viewport-relative widths, font sizes, and padding for better mobile presentation, including a portrait-specific layout for title and uploader card.