### PR TITLE
Add copy-link button, footer version, and hash-collision retry

### DIFF
--- a/client/css/landing.css
+++ b/client/css/landing.css
@@ -20,6 +20,10 @@
 			display: none;
 		}
 
+		&.toast-success {
+			background: #2a7a3a;
+		}
+
 		p {
 			margin: 0;
 			color: var(--color-chrome);

--- a/client/export.ts
+++ b/client/export.ts
@@ -43,6 +43,7 @@ export function initExport() {
 
 	function showError(message: string) {
 		errorToastText.textContent = message;
+		errorToast.classList.remove("toast-success");
 		errorToast.hidden = false;
 		if (errorToastTimeout) clearTimeout(errorToastTimeout);
 		errorToastTimeout = setTimeout(() => {

--- a/client/index.html
+++ b/client/index.html
@@ -32,7 +32,7 @@
                     <button type="button" class="export-option" data-format="webm">🎬 WebM</button>
                 </div>
             </div>
-            <button type="button" class="dock-btn" disabled title="Copy link (soon)" aria-label="Copy link (soon)">🔗</button>
+            <button type="button" id="copy-link-btn" class="dock-btn" title="Copy link" aria-label="Copy link">🔗</button>
         </div>
         <div id="landing">
             <div class="console-card">
@@ -101,7 +101,7 @@
         </dialog>
         <div id="pictures-container"></div>
         <footer>
-            <p><span class="status-dot"></span> root@shooting-stars:~$ credits --author "<a href="https://tekrop.fr" target="_blank">Valentin &quot;TeKrop&quot; PORCHET</a>" --terms "<a href="https://github.com/TeKrop/shooting-stars-meme-generator/blob/main/CGU.md" target="_blank">terms and conditions</a>" <span class="cursor">_</span></p>
+            <p><span class="status-dot"></span> root@shooting-stars:~$ credits --version "<span id="app-version"></span>" --author "<a href="https://tekrop.fr" target="_blank">Valentin &quot;TeKrop&quot; PORCHET</a>" --terms "<a href="https://github.com/TeKrop/shooting-stars-meme-generator/blob/main/CGU.md" target="_blank">terms and conditions</a>" <span class="cursor">_</span></p>
         </footer>
         <script type="module" src="./script.ts"></script>
     </body>

--- a/client/preview.ts
+++ b/client/preview.ts
@@ -63,6 +63,7 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 
 	function showUploadError(message: string) {
 		uploadErrorText.textContent = message;
+		uploadError.classList.remove("toast-success");
 		uploadError.hidden = false;
 		if (uploadErrorTimeout) clearTimeout(uploadErrorTimeout);
 		uploadErrorTimeout = setTimeout(() => {

--- a/client/script.ts
+++ b/client/script.ts
@@ -5,6 +5,12 @@ import { initPreviewDialog } from "./preview";
 
 const COPY_TOAST_DISMISS_MS = 4000;
 
+function requireElement<T extends Element>(id: string): T {
+	const el = document.getElementById(id);
+	if (!el) throw new Error(`Missing #${id} element in index.html`);
+	return el as unknown as T;
+}
+
 // pictures
 const picturesContainer = document.getElementById(
 	"pictures-container",
@@ -35,32 +41,43 @@ fileUpload.addEventListener("blur", () => {
 	document.body.classList.remove("file-upload-focused");
 });
 
-(document.getElementById("app-version") as HTMLElement).textContent =
-	`v${version}`;
+requireElement<HTMLElement>("app-version").textContent = `v${version}`;
 
 // copy-link: reuses the same toast element preview.ts/export.ts use for
 // error messages — a generic dismissible message, not error-specific
-const copyLinkBtn = document.getElementById(
-	"copy-link-btn",
-) as HTMLButtonElement;
-const copyToast = document.getElementById("upload-error") as HTMLElement;
+const copyLinkBtn = requireElement<HTMLButtonElement>("copy-link-btn");
+const copyToast = requireElement<HTMLElement>("upload-error");
 const copyToastText = copyToast.querySelector("p") as HTMLParagraphElement;
 let copyToastTimeout: ReturnType<typeof setTimeout> | null = null;
 
-copyLinkBtn.addEventListener("click", async () => {
-	try {
-		await navigator.clipboard.writeText(window.location.href);
-		copyToastText.textContent = "Link copied!";
-		copyToast.classList.add("toast-success");
-	} catch {
-		copyToastText.textContent = "Couldn't copy the link.";
-		copyToast.classList.remove("toast-success");
-	}
+function showCopyToast() {
 	copyToast.hidden = false;
 	if (copyToastTimeout) clearTimeout(copyToastTimeout);
 	copyToastTimeout = setTimeout(() => {
 		copyToast.hidden = true;
 	}, COPY_TOAST_DISMISS_MS);
+}
+
+copyLinkBtn.addEventListener("click", async () => {
+	// clipboard access needs a secure context (HTTPS/localhost) and can be
+	// denied by the user, so both are worth telling apart rather than one
+	// generic failure message
+	if (!navigator.clipboard) {
+		copyToastText.textContent = "Clipboard isn't available in this browser.";
+		copyToast.classList.remove("toast-success");
+		showCopyToast();
+		return;
+	}
+	try {
+		await navigator.clipboard.writeText(window.location.href);
+		copyToastText.textContent = "Link copied!";
+		copyToast.classList.add("toast-success");
+	} catch {
+		copyToastText.textContent =
+			"Couldn't copy the link — check clipboard permissions.";
+		copyToast.classList.remove("toast-success");
+	}
+	showCopyToast();
 });
 
 // init animation

--- a/client/script.ts
+++ b/client/script.ts
@@ -1,6 +1,9 @@
+import { version } from "../package.json";
 import { restartAnimation, startAnimation } from "./animation";
 import { initExport } from "./export";
 import { initPreviewDialog } from "./preview";
+
+const COPY_TOAST_DISMISS_MS = 4000;
 
 // pictures
 const picturesContainer = document.getElementById(
@@ -30,6 +33,34 @@ fileUpload.addEventListener("focus", () => {
 });
 fileUpload.addEventListener("blur", () => {
 	document.body.classList.remove("file-upload-focused");
+});
+
+(document.getElementById("app-version") as HTMLElement).textContent =
+	`v${version}`;
+
+// copy-link: reuses the same toast element preview.ts/export.ts use for
+// error messages — a generic dismissible message, not error-specific
+const copyLinkBtn = document.getElementById(
+	"copy-link-btn",
+) as HTMLButtonElement;
+const copyToast = document.getElementById("upload-error") as HTMLElement;
+const copyToastText = copyToast.querySelector("p") as HTMLParagraphElement;
+let copyToastTimeout: ReturnType<typeof setTimeout> | null = null;
+
+copyLinkBtn.addEventListener("click", async () => {
+	try {
+		await navigator.clipboard.writeText(window.location.href);
+		copyToastText.textContent = "Link copied!";
+		copyToast.classList.add("toast-success");
+	} catch {
+		copyToastText.textContent = "Couldn't copy the link.";
+		copyToast.classList.remove("toast-success");
+	}
+	copyToast.hidden = false;
+	if (copyToastTimeout) clearTimeout(copyToastTimeout);
+	copyToastTimeout = setTimeout(() => {
+		copyToast.hidden = true;
+	}, COPY_TOAST_DISMISS_MS);
 });
 
 // init animation

--- a/server/server.ts
+++ b/server/server.ts
@@ -10,6 +10,7 @@ import { type ExportFormat, renderExportInWorker } from "./export";
 // host-side port mapping is configurable, via APP_PORT in docker-compose.yml.
 const HTTP_PORT = 9595;
 const HASH_LENGTH = parseInt(process.env.HASH_LENGTH || "5", 10); // hash length for uploaded images URL
+const MAX_HASH_ATTEMPTS = 5; // ponytail: collision odds are ~1e-8 at default HASH_LENGTH; if all attempts collide, proceed and overwrite rather than erroring out
 
 const uploadsDir = `${import.meta.dir}/../uploads`;
 
@@ -169,7 +170,15 @@ const server = Bun.serve({
 					);
 				}
 
-				const hash = randomstring.generate(HASH_LENGTH);
+				let hash = randomstring.generate(HASH_LENGTH);
+				for (
+					let attempts = 0;
+					attempts < MAX_HASH_ATTEMPTS &&
+					(await Bun.file(`${uploadsDir}/${hash}.png`).exists());
+					attempts++
+				) {
+					hash = randomstring.generate(HASH_LENGTH);
+				}
 				const storedName = `${hash}.png`;
 				await Bun.write(`${uploadsDir}/${storedName}`, file);
 				log("upload OK:", storedName, file.type, `${file.size} bytes`);

--- a/server/server.ts
+++ b/server/server.ts
@@ -171,15 +171,15 @@ const server = Bun.serve({
 				}
 
 				let hash = randomstring.generate(HASH_LENGTH);
-				for (
-					let attempts = 0;
-					attempts < MAX_HASH_ATTEMPTS &&
-					(await Bun.file(`${uploadsDir}/${hash}.png`).exists());
-					attempts++
-				) {
+				let storedName = `${hash}.png`;
+				for (let attempts = 0; attempts < MAX_HASH_ATTEMPTS; attempts++) {
+					const collides = await Bun.file(
+						`${uploadsDir}/${storedName}`,
+					).exists();
+					if (!collides) break;
 					hash = randomstring.generate(HASH_LENGTH);
+					storedName = `${hash}.png`;
 				}
-				const storedName = `${hash}.png`;
 				await Bun.write(`${uploadsDir}/${storedName}`, file);
 				log("upload OK:", storedName, file.type, `${file.size} bytes`);
 				return withSecurityHeaders(Response.redirect(`/${hash}`, 303));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 		"target": "ESNext",
 		"module": "Preserve",
 		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
 		"lib": ["ESNext", "DOM", "DOM.Iterable"],
 		"types": ["bun"],
 		"allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary
- Wire up the previously-disabled 🔗 dock button to copy the current shareable `/<hash>` link to the clipboard, with a toast confirmation
- Show the app's `package.json` version in the footer's credits line
- Retry hash generation on upload if the generated hash already exists on disk, instead of silently overwriting an existing upload

## Test plan
- [x] `just check` (tsc + biome + stars.css freshness)
- [x] `just test` (20/20 pass)
- [x] Manual: `just dev`, uploaded an image, clicked 🔗, confirmed clipboard received the `/<hash>` URL and the green "Link copied!" toast appeared/dismissed
- [x] Manual: confirmed footer shows `--version "vX.Y.Z"` matching `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable copying the current shareable link with a toast notification, display the app version in the footer, and reduce the likelihood of upload hash collisions.

New Features:
- Add an interactive dock button that copies the current shareable URL to the clipboard with a success or failure toast.
- Show the application version from package.json in the footer credits line.

Bug Fixes:
- Avoid silently overwriting existing uploads by retrying hash generation a limited number of times when a collision is detected.

Enhancements:
- Reuse the existing toast component for non-error messages with a success style while ensuring error toasts clear the success state.
- Allow TypeScript to import package.json via resolveJsonModule for client-side version display.