### PR TITLE
feat: support paste and drag-and-drop image upload

### DIFF
--- a/client/css/buttons.css
+++ b/client/css/buttons.css
@@ -256,22 +256,12 @@
 		}
 	}
 
+	/* purely an internal control now — only ever clicked programmatically by
+       #source-browse-btn inside the preview dialog, never labeled/focused
+       directly (see tabindex="-1" in index.html) */
 	input#file-upload {
 		opacity: 0;
 		position: absolute;
 		z-index: -1;
-	}
-
-	/* the hidden file input can't be an adjacent sibling of both labels that
-       trigger it (they live in different parts of the DOM), so script.ts
-       toggles this class on <body> on focus/blur instead of relying on
-       :has() — keeps browser support universal and scopes the ring to only
-       the two actual upload triggers, not every .console-btn */
-	body.file-upload-focused {
-		.console-btn--secondary,
-		.dock-btn[for="file-upload"] {
-			outline: 2px solid var(--color-cyan);
-			outline-offset: 4px;
-		}
 	}
 }

--- a/client/css/dialog.css
+++ b/client/css/dialog.css
@@ -96,6 +96,7 @@
 		}
 	}
 
+	#source-step,
 	#crop-step,
 	#edit-step {
 		display: flex;
@@ -110,6 +111,44 @@
 		& > .tagline {
 			font-size: 20px;
 			color: var(--color-magenta-light);
+		}
+	}
+
+	#source-drop-zone {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 16px;
+		width: min(85vw, 800px);
+		height: 70vh;
+		border: 1.5px dashed rgba(var(--color-cyan-rgb), 0.35);
+		transition:
+			border-color 0.2s ease,
+			background 0.2s ease;
+
+		&.is-drag-over {
+			border-color: rgba(var(--color-cyan-rgb), 0.9);
+			background: rgba(var(--color-cyan-rgb), 0.08);
+		}
+	}
+
+	.source-drop-hint {
+		margin: 0;
+		color: var(--color-chrome);
+		font-family: sans-serif;
+		font-size: 13px;
+		opacity: 0.8;
+	}
+
+	#source-error {
+		margin: 0;
+		color: #ff9d9d;
+		font-family: sans-serif;
+		font-size: 13px;
+
+		&[hidden] {
+			display: none;
 		}
 	}
 

--- a/client/index.html
+++ b/client/index.html
@@ -21,10 +21,10 @@
             Your browser does not support the video tag.
         </video>
         <form id="upload-form" enctype="multipart/form-data" action="/upload" method="post">
-            <input type="file" id="file-upload" name="file-upload" accept="image/*" />
+            <input type="file" id="file-upload" name="file-upload" accept="image/*" tabindex="-1" />
         </form>
         <div id="quick-actions">
-            <label for="file-upload" class="dock-btn" title="Upload your pic" aria-label="Upload your pic">📤</label>
+            <button type="button" class="dock-btn upload-trigger" title="Upload your pic" aria-label="Upload your pic">📤</button>
             <div id="export-group">
                 <button type="button" id="export-btn" class="dock-btn" title="Export as video" aria-label="Export as video" aria-haspopup="true" aria-expanded="false">💾</button>
                 <div id="export-menu" hidden>
@@ -46,7 +46,7 @@
                     <button type="button" id="tap-to-play" class="console-btn console-btn--primary">
                         <p></p>
                     </button>
-                    <label for="file-upload" class="console-btn console-btn--secondary">📤 Upload your pic</label>
+                    <button type="button" class="console-btn console-btn--secondary upload-trigger">📤 Upload your pic</button>
                 </div>
             </div>
         </div>
@@ -56,8 +56,17 @@
         </div>
         <dialog id="preview-dialog">
             <div class="preview-card">
-                <div id="crop-step">
-                    <p class="tagline">✦ Step 1: Crop ✦</p>
+                <div id="source-step">
+                    <p class="tagline">✦ Step 1: Add an image ✦</p>
+                    <div id="source-drop-zone">
+                        <p class="source-drop-hint">Drag &amp; drop an image here, or paste from your clipboard</p>
+                        <button type="button" id="source-browse-btn" class="console-btn console-btn--secondary">📤 Browse files</button>
+                    </div>
+                    <p id="source-error" role="alert" hidden></p>
+                </div>
+
+                <div id="crop-step" hidden>
+                    <p class="tagline">✦ Step 2: Crop ✦</p>
                     <div id="crop-area">
                         <img id="preview-img" alt="Preview">
                     </div>
@@ -65,7 +74,7 @@
                 </div>
 
                 <div id="edit-step" hidden>
-                    <p class="tagline">✦ Step 2: Transparency ✦</p>
+                    <p class="tagline">✦ Step 3: Transparency ✦</p>
                     <canvas id="edit-canvas"></canvas>
                     <div class="tool-picker">
                         <button id="tool-erase" type="button" aria-pressed="true">🧽 Erase</button>
@@ -87,7 +96,7 @@
                 <div class="preview-actions">
                     <button id="preview-cancel" type="button">✕ Cancel</button>
                     <button id="edit-back" type="button" hidden>⬅ Back</button>
-                    <button id="crop-next" type="button">Next ➔</button>
+                    <button id="crop-next" type="button" hidden>Next ➔</button>
                     <button id="preview-confirm" type="button" hidden>✦ Upload ✦</button>
                 </div>
             </div>

--- a/client/preview.ts
+++ b/client/preview.ts
@@ -117,21 +117,33 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 				return;
 			}
 		}
+		// clipboard had content but none of it was an image (e.g. copied text)
+		showSourceError("Clipboard doesn't contain an image.");
 	}
 
-	function showSourceStep() {
-		sourceStep.hidden = false;
-		cropStep.hidden = true;
-		editStep.hidden = true;
-		nextBtn.hidden = true;
-		backBtn.hidden = true;
-		uploadBtn.hidden = true;
-		sourceError.hidden = true;
-		previewDialog.addEventListener("paste", handlePaste);
+	type Step = "source" | "crop" | "edit";
+
+	// centralizes the per-step hidden/visible state for the dialog's three
+	// steps and their nav buttons, instead of each step-entry point setting
+	// all six flags by hand
+	function setStep(step: Step) {
+		sourceStep.hidden = step !== "source";
+		cropStep.hidden = step !== "crop";
+		editStep.hidden = step !== "edit";
+		nextBtn.hidden = step !== "crop";
+		backBtn.hidden = step !== "edit";
+		uploadBtn.hidden = step !== "edit";
+
+		if (step === "source") {
+			previewDialog.addEventListener("paste", handlePaste);
+		} else {
+			previewDialog.removeEventListener("paste", handlePaste);
+			sourceError.hidden = true;
+		}
 	}
 
 	function openSourceStep() {
-		showSourceStep();
+		setStep("source");
 		previewDialog.showModal();
 	}
 
@@ -141,6 +153,7 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 
 	sourceDropZone.ondragover = (e) => {
 		e.preventDefault();
+		if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
 		sourceDropZone.classList.add("is-drag-over");
 	};
 	sourceDropZone.ondragleave = () => {
@@ -172,13 +185,7 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 	cancelBtn.onclick = () => previewDialog.close();
 
 	function showCropStep() {
-		sourceStep.hidden = true;
-		previewDialog.removeEventListener("paste", handlePaste);
-		cropStep.hidden = false;
-		editStep.hidden = true;
-		nextBtn.hidden = false;
-		backBtn.hidden = true;
-		uploadBtn.hidden = true;
+		setStep("crop");
 		// a previous upload in this same dialog session may have left these
 		// set — reset them so a fresh upload isn't stuck disabled/loading
 		uploadBtn.disabled = false;
@@ -234,11 +241,7 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 		editCanvas.height = canvas.height;
 		editCtx.drawImage(canvas, 0, 0);
 
-		cropStep.hidden = true;
-		editStep.hidden = false;
-		nextBtn.hidden = true;
-		backBtn.hidden = false;
-		uploadBtn.hidden = false;
+		setStep("edit");
 
 		// must run after editStep is unhidden: the erase cursor is sized from
 		// the canvas's displayed rect, which is 0x0 while hidden

--- a/client/preview.ts
+++ b/client/preview.ts
@@ -31,6 +31,16 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 	) as HTMLDialogElement;
 	const previewImg = document.getElementById("preview-img") as HTMLImageElement;
 	const cropArea = document.getElementById("crop-area") as HTMLElement;
+	const sourceStep = document.getElementById("source-step") as HTMLElement;
+	const sourceDropZone = document.getElementById(
+		"source-drop-zone",
+	) as HTMLElement;
+	const sourceBrowseBtn = document.getElementById(
+		"source-browse-btn",
+	) as HTMLButtonElement;
+	const sourceError = document.getElementById("source-error") as HTMLElement;
+	const uploadTriggers =
+		document.querySelectorAll<HTMLButtonElement>(".upload-trigger");
 	const cropStep = document.getElementById("crop-step") as HTMLElement;
 	const editStep = document.getElementById("edit-step") as HTMLElement;
 	const editCanvas = document.getElementById(
@@ -76,15 +86,76 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 		if (uploadErrorTimeout) clearTimeout(uploadErrorTimeout);
 	};
 
-	fileInput.onchange = () => {
-		const file = fileInput.files?.[0];
-		if (!file) return;
+	function showSourceError(message: string) {
+		sourceError.textContent = message;
+		sourceError.hidden = false;
+	}
+
+	function openPreviewWithFile(file: File) {
+		if (!file.type.startsWith("image/")) {
+			showSourceError("Please choose an image file.");
+			return;
+		}
 
 		if (objectUrl) URL.revokeObjectURL(objectUrl);
 		objectUrl = URL.createObjectURL(file);
 		previewImg.src = objectUrl;
 		showCropStep();
+		if (!previewDialog.open) previewDialog.showModal();
+	}
+
+	function handlePaste(e: ClipboardEvent) {
+		const items = e.clipboardData?.items;
+		if (!items) return;
+		for (const item of items) {
+			if (item.type.startsWith("image/")) {
+				const file = item.getAsFile();
+				if (file) {
+					e.preventDefault();
+					openPreviewWithFile(file);
+				}
+				return;
+			}
+		}
+	}
+
+	function showSourceStep() {
+		sourceStep.hidden = false;
+		cropStep.hidden = true;
+		editStep.hidden = true;
+		nextBtn.hidden = true;
+		backBtn.hidden = true;
+		uploadBtn.hidden = true;
+		sourceError.hidden = true;
+		previewDialog.addEventListener("paste", handlePaste);
+	}
+
+	function openSourceStep() {
+		showSourceStep();
 		previewDialog.showModal();
+	}
+
+	for (const btn of uploadTriggers) btn.onclick = openSourceStep;
+
+	sourceBrowseBtn.onclick = () => fileInput.click();
+
+	sourceDropZone.ondragover = (e) => {
+		e.preventDefault();
+		sourceDropZone.classList.add("is-drag-over");
+	};
+	sourceDropZone.ondragleave = () => {
+		sourceDropZone.classList.remove("is-drag-over");
+	};
+	sourceDropZone.ondrop = (e) => {
+		e.preventDefault();
+		sourceDropZone.classList.remove("is-drag-over");
+		const file = e.dataTransfer?.files[0];
+		if (file) openPreviewWithFile(file);
+	};
+
+	fileInput.onchange = () => {
+		const file = fileInput.files?.[0];
+		if (file) openPreviewWithFile(file);
 	};
 
 	// covers both the Cancel button and native Escape-to-close on <dialog>
@@ -94,11 +165,15 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 		if (objectUrl) URL.revokeObjectURL(objectUrl);
 		objectUrl = null;
 		fileInput.value = "";
+		previewDialog.removeEventListener("paste", handlePaste);
+		sourceError.hidden = true;
 	};
 
 	cancelBtn.onclick = () => previewDialog.close();
 
 	function showCropStep() {
+		sourceStep.hidden = true;
+		previewDialog.removeEventListener("paste", handlePaste);
 		cropStep.hidden = false;
 		editStep.hidden = true;
 		nextBtn.hidden = false;

--- a/client/script.ts
+++ b/client/script.ts
@@ -28,19 +28,6 @@ for (let i = nbPictures; i >= 1; i--) {
 	picturesContainer.appendChild(img);
 }
 
-// the hidden file input can't rely on CSS's adjacent-sibling focus trick
-// since it has two labels in different parts of the DOM (see .file-upload-focused
-// in style.css) — toggling a class here works in every browser, unlike :has()
-const fileUpload = document.getElementById("file-upload") as HTMLInputElement;
-fileUpload.addEventListener("focus", () => {
-	if (fileUpload.matches(":focus-visible")) {
-		document.body.classList.add("file-upload-focused");
-	}
-});
-fileUpload.addEventListener("blur", () => {
-	document.body.classList.remove("file-upload-focused");
-});
-
 requireElement<HTMLElement>("app-version").textContent = `v${version}`;
 
 // copy-link: reuses the same toast element preview.ts/export.ts use for


### PR DESCRIPTION
## Summary
- Adds a new intermediary dialog step ("Add an image") shown before cropping, offering drag-and-drop and clipboard paste alongside the existing native file picker
- Both upload entry points (dock icon, landing card button) now open the dialog straight to this step instead of the OS file picker
- Native file picker stays available as a "Browse files" fallback inside the new step
- Drag-and-drop and paste are scoped to the dialog's new step only (not page-wide), per design discussion
- Removes the now-dead two-`<label>` focus-relay hack in favor of native `:focus-visible` on real `<button>` triggers

## Test plan
- [x] `just check` (tsc + biome + stars.css freshness) passes
- [x] Manually verified in browser: dialog opens to the new step from both triggers
- [x] Drag-and-drop of an image advances to crop step with drag-over highlight
- [x] Clipboard paste of an image advances to crop step
- [x] Dropping/pasting a non-image shows an inline error and stays on the step
- [x] "Browse files" still opens the native file picker and works as before
- [x] Full flow (crop → transparency → upload) still completes and animates correctly
- [x] Tab order: upload triggers get a visible focus ring, hidden file input is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an intermediary image source step to the upload dialog that supports drag-and-drop and clipboard paste, and route existing upload triggers through this new step.

New Features:
- Allow users to upload images via drag-and-drop into a dedicated drop zone within the preview dialog.
- Allow users to upload images by pasting from the clipboard while the source step is active.
- Add an in-dialog "Browse files" button that opens the existing native file picker as a fallback image source.

Enhancements:
- Introduce a dedicated "Add an image" source step in the preview dialog before cropping, updating subsequent steps and controls accordingly.
- Scope drag-and-drop and paste handling to the preview dialog’s source step instead of the entire page.
- Replace label-based upload triggers with real buttons that open the new source step and rely on native focus-visible behavior.
- Hide the underlying file input from the tab order and treat it as an internal control only.