### PR TITLE
feat: add background video volume control

### DIFF
--- a/client/animation.ts
+++ b/client/animation.ts
@@ -9,6 +9,15 @@ video.volume = 0.05;
 // once the video has ended, restart the animation
 video.addEventListener("ended", restartAnimation, false);
 
+/**
+ * Lets other modules (currently just volume.ts) read/mutate playback
+ * properties like .volume/.muted without each grabbing their own
+ * `document.getElementById("video")` reference
+ */
+export function getVideoElement(): HTMLVideoElement {
+	return video;
+}
+
 const landing = document.getElementById("landing") as HTMLElement;
 const starfield = document.getElementById("starfield") as HTMLElement;
 const tapToPlay = document.getElementById("tap-to-play") as HTMLElement;

--- a/client/css/buttons.css
+++ b/client/css/buttons.css
@@ -256,6 +256,61 @@
 		}
 	}
 
+	/* the volume popover that opens from #volume-btn — same shape as
+       #export-group/#export-menu above */
+	#volume-group {
+		position: relative;
+	}
+
+	#volume-menu {
+		position: absolute;
+		top: calc(100% + 8px);
+		left: 0;
+		z-index: 3;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 12px;
+		background: rgba(var(--color-void-rgb), 0.85);
+		border: 1.5px solid rgba(var(--color-cyan-rgb), 0.5);
+		backdrop-filter: blur(10px);
+		-webkit-backdrop-filter: blur(10px);
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
+	#mute-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+		font-size: 15px;
+		color: var(--color-chrome);
+		background: transparent;
+		border: none;
+		cursor: pointer;
+
+		&:hover,
+		&:focus-visible {
+			color: var(--color-cyan);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-cyan);
+			outline-offset: 2px;
+		}
+	}
+
+	#volume-slider {
+		width: 100px;
+		accent-color: var(--color-cyan);
+		cursor: pointer;
+	}
+
 	/* purely an internal control now — only ever clicked programmatically by
        #source-browse-btn inside the preview dialog, never labeled/focused
        directly (see tabindex="-1" in index.html) */

--- a/client/index.html
+++ b/client/index.html
@@ -32,6 +32,13 @@
                     <button type="button" class="export-option" data-format="webm">🎬 WebM</button>
                 </div>
             </div>
+            <div id="volume-group">
+                <button type="button" id="volume-btn" class="dock-btn" title="Volume" aria-label="Volume" aria-haspopup="true" aria-expanded="false">🔊</button>
+                <div id="volume-menu" hidden>
+                    <button type="button" id="mute-btn" title="Mute" aria-label="Mute" aria-pressed="false">🔊</button>
+                    <input type="range" id="volume-slider" min="0" max="100" value="5" aria-label="Volume">
+                </div>
+            </div>
             <button type="button" id="copy-link-btn" class="dock-btn" title="Copy link" aria-label="Copy link">🔗</button>
         </div>
         <div id="landing">

--- a/client/script.ts
+++ b/client/script.ts
@@ -2,6 +2,7 @@ import { version } from "../package.json";
 import { restartAnimation, startAnimation } from "./animation";
 import { initExport } from "./export";
 import { initPreviewDialog } from "./preview";
+import { initVolumeControl } from "./volume";
 
 const COPY_TOAST_DISMISS_MS = 4000;
 
@@ -72,6 +73,7 @@ restartAnimation();
 
 initPreviewDialog(applyUploadedImage);
 initExport();
+initVolumeControl();
 
 /**
  * Swaps in a freshly uploaded image without a full page reload: updates the

--- a/client/volume.ts
+++ b/client/volume.ts
@@ -1,0 +1,69 @@
+// background-video volume control that lives in the persistent
+// #quick-actions dock — see export.ts for the popover pattern this mirrors
+
+import { getVideoElement } from "./animation";
+
+const MUTED_ICON = "🔇";
+const UNMUTED_ICON = "🔊";
+
+export function initVolumeControl() {
+	const video = getVideoElement();
+
+	const volumeGroup = document.getElementById("volume-group") as HTMLElement;
+	const volumeBtn = document.getElementById("volume-btn") as HTMLButtonElement;
+	const volumeMenu = document.getElementById("volume-menu") as HTMLElement;
+	const muteBtn = document.getElementById("mute-btn") as HTMLButtonElement;
+	const volumeSlider = document.getElementById(
+		"volume-slider",
+	) as HTMLInputElement;
+
+	// reflect whatever animation.ts actually set as the default rather than
+	// hardcoding a second default here that could drift out of sync
+	volumeSlider.value = String(Math.round(video.volume * 100));
+
+	function setMenuOpen(open: boolean) {
+		volumeMenu.hidden = !open;
+		volumeBtn.setAttribute("aria-expanded", String(open));
+	}
+
+	// volume 0 and .muted both play silently, so either one should read as
+	// "muted" in the UI even if only one of them is technically true
+	function isMuted(): boolean {
+		return video.muted || video.volume === 0;
+	}
+
+	function updateMuteUI() {
+		const muted = isMuted();
+		const icon = muted ? MUTED_ICON : UNMUTED_ICON;
+		volumeBtn.textContent = icon;
+		muteBtn.textContent = icon;
+		muteBtn.setAttribute("aria-pressed", String(muted));
+		muteBtn.title = muted ? "Unmute" : "Mute";
+		muteBtn.setAttribute("aria-label", muted ? "Unmute" : "Mute");
+	}
+
+	volumeBtn.addEventListener("click", () => {
+		setMenuOpen(!!volumeMenu.hidden);
+	});
+
+	// closes the popover on any click outside the group, same as export.ts
+	document.addEventListener("click", (e) => {
+		if (!volumeGroup.contains(e.target as Node)) setMenuOpen(false);
+	});
+
+	muteBtn.addEventListener("click", () => {
+		video.muted = !video.muted;
+		updateMuteUI();
+	});
+
+	// dragging the slider always implies "I want sound", matching native
+	// media-player convention (un-mutes even if dragged back down to 0,
+	// which then just reads as muted again via isMuted()'s volume===0 check)
+	volumeSlider.addEventListener("input", () => {
+		video.volume = Number(volumeSlider.value) / 100;
+		video.muted = false;
+		updateMuteUI();
+	});
+
+	updateMuteUI();
+}

--- a/client/volume.ts
+++ b/client/volume.ts
@@ -51,6 +51,13 @@ export function initVolumeControl() {
 		if (!volumeGroup.contains(e.target as Node)) setMenuOpen(false);
 	});
 
+	// Escape closes the popover regardless of which element inside it is
+	// focused, so keyboard users get the same dismissal outside-click gives
+	// mouse users
+	document.addEventListener("keydown", (e) => {
+		if (e.key === "Escape" && !volumeMenu.hidden) setMenuOpen(false);
+	});
+
 	muteBtn.addEventListener("click", () => {
 		video.muted = !video.muted;
 		updateMuteUI();


### PR DESCRIPTION
## Summary
- Adds a mute toggle + volume slider popover to the persistent `#quick-actions` dock, mirroring the existing export-menu popover pattern
- Exposes the background video element from `animation.ts` via `getVideoElement()` for the new `volume.ts` module to control
- No persistence across page loads — resets to the current default (5%, unmuted) every time

## Test plan
- [x] `just check` passes (tsc, biome, stars.css freshness)
- [x] Manually verified in browser: popover opens/closes on click and outside-click, mute toggle flips both dock and popover icons in sync, slider changes volume and auto-unmutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a background video volume control popover to the quick-actions dock and expose the video element for shared control.

New Features:
- Introduce a dock volume control popover with mute toggle and slider for the background video.

Enhancements:
- Expose the background video element via a shared getter for reuse by other modules.
- Align styling and accessibility attributes of the new volume controls with existing dock and popover patterns.