### PR TITLE
fix: skip upload dialog step 1 on mobile, fix fullscreen editing perf/layout

### DIFF
--- a/client/css/base.css
+++ b/client/css/base.css
@@ -17,6 +17,7 @@
 	}
 
 	body {
+		margin: 0;
 		width: 100%;
 		height: 100%;
 		background-color: black;

--- a/client/css/buttons.css
+++ b/client/css/buttons.css
@@ -311,9 +311,11 @@
 		cursor: pointer;
 	}
 
-	/* purely an internal control now — only ever clicked programmatically by
-       #source-browse-btn inside the preview dialog, never labeled/focused
-       directly (see tabindex="-1" in index.html) */
+	/* purely an internal control now — only ever clicked programmatically,
+       either by #source-browse-btn inside the preview dialog or, on mobile
+       (which skips straight past the source step), directly by the
+       .upload-trigger buttons — never labeled/focused directly (see
+       tabindex="-1" in index.html) */
 	input#file-upload {
 		opacity: 0;
 		position: absolute;

--- a/client/css/responsive.css
+++ b/client/css/responsive.css
@@ -97,6 +97,84 @@
 		}
 	}
 
+	/* touch-primary devices can't drag-and-drop or Ctrl-V paste (see
+       client/preview.ts's matching isMobile() check, which skips the
+       source step entirely on these), and the floating card's live
+       backdrop-filter/box-shadow are expensive to keep compositing over
+       the still-animating starfield/video underneath on a mobile GPU — so
+       here the dialog goes fullscreen and opaque instead of floating+blurred */
+	@media (hover: none) and (pointer: coarse) {
+		/* the UA default for dialog:modal caps it at ~100% minus its own
+           border/margin and sets overflow:auto — without overriding that
+           cap here, the card below (forced to a true 100vw/100dvh) ends up
+           slightly bigger than its own <dialog> parent box, and that
+           leftover UA overflow:auto is what was producing the scrollbars */
+		dialog#preview-dialog {
+			width: 100vw;
+			height: 100dvh;
+			max-width: 100vw;
+			max-height: 100dvh;
+		}
+
+		dialog#preview-dialog::backdrop {
+			backdrop-filter: none;
+		}
+
+		.preview-card {
+			width: 100vw;
+			height: 100dvh;
+			max-width: 100vw;
+			max-height: 100dvh;
+			padding: 12px;
+			border-radius: 0;
+			clip-path: none;
+			backdrop-filter: none;
+			box-shadow: none;
+			box-sizing: border-box;
+		}
+
+		/* one flex item (the active step) plus .preview-actions share the
+           card's height; the step grows to fill whatever's left instead of
+           a fixed vw/dvh box that doesn't know how tall its own siblings
+           (tagline, hint text, buttons) actually are — that mismatch is
+           what caused the scrollbars */
+		#source-step,
+		#crop-step,
+		#edit-step {
+			flex: 1;
+			min-height: 0;
+			width: 100%;
+		}
+
+		/* plain boxes with no intrinsic aspect ratio: fill whatever space
+           the step grants them */
+		#source-drop-zone,
+		#crop-area {
+			flex: 1;
+			min-height: 0;
+			width: 100%;
+			max-width: 100%;
+			max-height: 100%;
+		}
+
+		/* unlike the two above, #edit-canvas has a real pixel aspect ratio
+           (set from the cropped image in preview.ts) — flex:1 (flex-basis:
+           0) lets it correctly share space with its siblings (tagline,
+           tool-picker/sliders) without a fixed vw/dvh box, but that same
+           flex-basis:0 doesn't reliably preserve aspect ratio for every
+           source image (most visible on a square crop, where any stretch
+           is obvious). object-fit: contain fixes that split: flexbox is
+           free to size the box however it wants, while the canvas's own
+           rendered bitmap stays letterboxed at its correct ratio inside it */
+		#edit-canvas {
+			flex: 1;
+			min-height: 0;
+			max-width: 100%;
+			max-height: 100%;
+			object-fit: contain;
+		}
+	}
+
 	@media (orientation: portrait) {
 		.console-card {
 			padding: clamp(20px, 4vh, 32px) clamp(16px, 5vw, 32px);

--- a/client/preview.ts
+++ b/client/preview.ts
@@ -148,13 +148,18 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 	}
 
 	// drag & drop and clipboard paste (the whole point of the source step)
-	// aren't reachable on a touchscreen, so mobile skips it and goes straight
-	// to the native file picker
-	const isMobile = () =>
-		window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+	// aren't reachable when there's no precise pointer available at all —
+	// computed once since input capability doesn't change over a dialog
+	// session. Requiring *both* a coarse/no-hover primary pointer AND no
+	// fine pointer available as a secondary input (any-pointer) avoids
+	// misclassifying a hybrid touchscreen laptop/tablet that also has a
+	// mouse or trackpad attached, which still gets the full desktop flow
+	const isMobile =
+		window.matchMedia("(hover: none) and (pointer: coarse)").matches &&
+		!window.matchMedia("(any-pointer: fine)").matches;
 
 	for (const btn of uploadTriggers) {
-		btn.onclick = isMobile() ? () => fileInput.click() : openSourceStep;
+		btn.onclick = isMobile ? () => fileInput.click() : openSourceStep;
 	}
 
 	sourceBrowseBtn.onclick = () => fileInput.click();

--- a/client/preview.ts
+++ b/client/preview.ts
@@ -147,7 +147,15 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 		previewDialog.showModal();
 	}
 
-	for (const btn of uploadTriggers) btn.onclick = openSourceStep;
+	// drag & drop and clipboard paste (the whole point of the source step)
+	// aren't reachable on a touchscreen, so mobile skips it and goes straight
+	// to the native file picker
+	const isMobile = () =>
+		window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+
+	for (const btn of uploadTriggers) {
+		btn.onclick = isMobile() ? () => fileInput.click() : openSourceStep;
+	}
 
 	sourceBrowseBtn.onclick = () => fileInput.click();
 

--- a/client/transparency.ts
+++ b/client/transparency.ts
@@ -113,8 +113,14 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 	eraseBtn.onclick = () => setTool("erase");
 	pickBtn.onclick = () => setTool("pick");
 
-	function canvasPoint(e: PointerEvent): { x: number; y: number } {
-		const rect = contentRect();
+	// rect is passed in (rather than calling contentRect() here) so a drag
+	// can compute it once at pointerdown and reuse it for every pointermove —
+	// getBoundingClientRect() can force a layout reflow, too costly to pay
+	// on every move event of a hot drag loop
+	function canvasPoint(
+		e: PointerEvent,
+		rect: ReturnType<typeof contentRect>,
+	): { x: number; y: number } {
 		return {
 			x: ((e.clientX - rect.left) * canvas.width) / rect.width,
 			y: ((e.clientY - rect.top) * canvas.height) / rect.height,
@@ -151,7 +157,9 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 	}
 
 	canvas.onpointerdown = (e: PointerEvent) => {
-		const point = canvasPoint(e);
+		// computed once for the whole stroke, not per move — see canvasPoint
+		const rect = contentRect();
+		const point = canvasPoint(e, rect);
 		pushHistory();
 
 		if (tool === "pick") {
@@ -167,7 +175,7 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		let pendingPoint: { x: number; y: number } | null = null;
 		let rafScheduled = false;
 		const onMove = (moveEvent: PointerEvent) => {
-			pendingPoint = canvasPoint(moveEvent);
+			pendingPoint = canvasPoint(moveEvent, rect);
 			if (rafScheduled) return;
 			rafScheduled = true;
 			requestAnimationFrame(() => {

--- a/client/transparency.ts
+++ b/client/transparency.ts
@@ -57,6 +57,27 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		updateHistoryButtons();
 	};
 
+	// the mobile fullscreen dialog styles #edit-canvas with object-fit:
+	// contain, which can letterbox the rendered bitmap inside the element's
+	// own box (its aspect ratio no longer has to match the canvas's) — this
+	// resolves the actual rendered content rect so pointer math and cursor
+	// sizing scale against it instead of the (possibly larger) element box
+	function contentRect() {
+		const rect = canvas.getBoundingClientRect();
+		const scale = Math.min(
+			rect.width / canvas.width,
+			rect.height / canvas.height,
+		);
+		const width = canvas.width * scale;
+		const height = canvas.height * scale;
+		return {
+			left: rect.left + (rect.width - width) / 2,
+			top: rect.top + (rect.height - height) / 2,
+			width,
+			height,
+		};
+	}
+
 	// draws the brush outline as the canvas cursor itself, so hovering shows
 	// exactly what the next erase will cover (scaled from canvas pixels to
 	// displayed CSS pixels, since the canvas can be shown smaller than its
@@ -67,8 +88,7 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		const radius = Number(eraseSizeInput.value);
 		if (!Number.isFinite(radius) || radius <= 0) return;
 
-		const displayRadius =
-			(radius * canvas.getBoundingClientRect().width) / canvas.width;
+		const displayRadius = (radius * contentRect().width) / canvas.width;
 		// rasterize at devicePixelRatio so the outline stays crisp (not
 		// blurry-upscaled) on high-DPI screens; cursor hotspot/size are in
 		// raster pixels, so everything below is scaled by dpr together
@@ -94,7 +114,7 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 	pickBtn.onclick = () => setTool("pick");
 
 	function canvasPoint(e: PointerEvent): { x: number; y: number } {
-		const rect = canvas.getBoundingClientRect();
+		const rect = contentRect();
 		return {
 			x: ((e.clientX - rect.left) * canvas.width) / rect.width,
 			y: ((e.clientY - rect.top) * canvas.height) / rect.height,
@@ -142,9 +162,18 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		eraseAt(point.x, point.y);
 		canvas.setPointerCapture(e.pointerId);
 
+		// touch pointermove can fire faster than the display refreshes;
+		// coalesce to at most one erase draw per frame instead of one per event
+		let pendingPoint: { x: number; y: number } | null = null;
+		let rafScheduled = false;
 		const onMove = (moveEvent: PointerEvent) => {
-			const p = canvasPoint(moveEvent);
-			eraseAt(p.x, p.y);
+			pendingPoint = canvasPoint(moveEvent);
+			if (rafScheduled) return;
+			rafScheduled = true;
+			requestAnimationFrame(() => {
+				rafScheduled = false;
+				if (pendingPoint) eraseAt(pendingPoint.x, pendingPoint.y);
+			});
 		};
 		// 'lostpointercapture' — rather than 'pointerup' alone — is what
 		// actually guarantees cleanup: it fires whenever capture ends for


### PR DESCRIPTION
## Summary
- On mobile (touch-primary devices), upload triggers now go straight to the native file picker instead of showing the drag-and-drop/paste-only source step, which is unreachable without a mouse/keyboard.
- The crop/transparency dialog is now fullscreen and opaque on mobile instead of a floating, blurred card over the still-animating starfield/video — the live `backdrop-filter` blur layers were the likely cause of reported mobile lag.
- The erase tool's `pointermove` handler is now batched to at most one draw per animation frame instead of one per event.
- Fixed two layout bugs found while verifying the above:
  - The native `<dialog>` element's own UA-default `max-width`/`max-height` cap (plus its default `overflow: auto`) was slightly smaller than the fullscreen card forced inside it, producing scrollbars in the dialog on mobile.
  - `body` was missing `margin: 0`, so the browser's default 8px margin pushed its box past the viewport — clipped visually by `html { overflow: hidden }` on desktop, but still touch-scrollable on mobile (homepage scrollbars).
- Fixed pointer/erase-position drift introduced by making `#edit-canvas` use `object-fit: contain` (to stop the canvas bitmap from stretching under flexbox sizing): pointer math and cursor sizing now resolve against the canvas's actual rendered (possibly letterboxed) content rect instead of its full element box.

## Test plan
- [x] `just check` (tsc, biome, stars.css freshness)
- [x] Manual verification via a phone-sized viewport in Chrome: upload triggers open the native file picker directly (no step 1) on mobile; dialog is fullscreen with no blur/scrollbars through crop and transparency steps; square-image crop renders un-stretched in both steps; erase tool erases exactly where clicked/dragged, verified against the letterboxed content rect math; homepage `scrollWidth`/`scrollHeight` now match `innerWidth`/`innerHeight` exactly at mobile viewport sizes
- [x] Desktop (mouse) path manually re-confirmed unchanged: upload trigger still opens the step-1 drop zone/paste screen, dialog still floats centered with blur

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize the image upload and editing flow on mobile by skipping the source step, making the preview dialog fullscreen, and improving erase interaction accuracy and performance.

New Features:
- Allow mobile upload triggers to open the native file picker directly instead of showing the source step.

Bug Fixes:
- Resolve mobile preview dialog scrollbars by fully sizing the <dialog> and card to the viewport.
- Fix homepage body overflow by removing the default body margin.
- Correct erase tool pointer and cursor math to account for letterboxed canvas content when using object-fit: contain.

Enhancements:
- Adjust mobile preview dialog styling to be fullscreen, opaque, and unblurred to reduce GPU compositing overhead.
- Make preview steps and content areas flex to share vertical space and avoid fixed viewport-based sizing issues.
- Batch erase pointermove handling to at most one draw per animation frame to reduce unnecessary work on touch devices.