### PR TITLE
fix: disable starfield animation on mobile for perf

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/client/css/responsive.css
+++ b/client/css/responsive.css
@@ -104,6 +104,15 @@
        the still-animating starfield/video underneath on a mobile GPU — so
        here the dialog goes fullscreen and opaque instead of floating+blurred */
 	@media (hover: none) and (pointer: coarse) {
+		/* the starfield's continuous background-position/opacity keyframes
+           over a 7-layer radial-gradient are a real repaint cost on mobile
+           GPUs, running non-stop even on the idle landing screen — it's
+           pure decoration (not the video, which stays untouched), so
+           hiding it here just falls back to body's own black background */
+		#starfield {
+			display: none;
+		}
+
 		/* the UA default for dialog:modal caps it at ~100% minus its own
            border/margin and sets overflow:auto — without overriding that
            cap here, the card below (forced to a true 100vw/100dvh) ends up


### PR DESCRIPTION
## Summary
- The idle-screen starfield (`#starfield`) runs two `infinite` keyframe animations non-stop, including one that animates `background-position` on a 7-layer radial-gradient — a real repaint cost on mobile GPUs, not a cheap compositor-only op.
- It's pure decoration layered above the background video, so it's disabled via the existing `(hover: none) and (pointer: coarse)` mobile media query in `client/css/responsive.css` (same convention already used there for the preview dialog's backdrop-filter/box-shadow removal).
- Background video is untouched — it's core content, not decoration, so it keeps playing/decoding normally on mobile.
- No JS changes needed: `animation.ts` only toggles `#starfield`'s `.fade-out` class, which is a no-op on a `display: none` element.
- Also bumped the Biome schema version in `biome.json` (2.5.4 → 2.5.5).

## Test plan
- [x] `just check` passes (typecheck, lint, stars.css freshness)
- [x] Verify in Chrome DevTools device emulation (or a real phone): landing screen shows plain black instead of the twinkling starfield, video/animation still plays normally
- [x] Confirm desktop (mouse/trackpad) still shows the starfield unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Disable the idle-screen starfield animation on mobile devices to reduce GPU repaint overhead while keeping the background video unchanged.

Bug Fixes:
- Prevent unnecessary continuous starfield repaint work on mobile by hiding the decorative starfield under the mobile hover/pointer media query.

Build:
- Bump Biome configuration schema version from 2.5.4 to 2.5.5.