### PR TITLE
feat: export options dialog (orientation/resolution/framerate/GIF)

### DIFF
--- a/client/css/buttons.css
+++ b/client/css/buttons.css
@@ -211,53 +211,9 @@
 		}
 	}
 
-	/* the format picker that opens from #export-btn */
-	#export-group {
-		position: relative;
-	}
-
-	#export-menu {
-		position: absolute;
-		top: calc(100% + 8px);
-		left: 0;
-		z-index: 3;
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
-		padding: 6px;
-		background: rgba(var(--color-void-rgb), 0.85);
-		border: 1.5px solid rgba(var(--color-cyan-rgb), 0.5);
-		backdrop-filter: blur(10px);
-		-webkit-backdrop-filter: blur(10px);
-
-		&[hidden] {
-			display: none;
-		}
-	}
-
-	.export-option {
-		white-space: nowrap;
-		padding: 8px 14px;
-		font-size: 14px;
-		color: var(--color-chrome);
-		background: transparent;
-		border: none;
-		cursor: pointer;
-		text-align: left;
-
-		&:hover,
-		&:focus-visible {
-			background: rgba(var(--color-cyan-rgb), 0.25);
-		}
-
-		&:focus-visible {
-			outline: 2px solid var(--color-cyan);
-			outline-offset: -2px;
-		}
-	}
-
-	/* the volume popover that opens from #volume-btn — same shape as
-       #export-group/#export-menu above */
+	/* the volume popover that opens from #volume-btn — export now opens a
+       full <dialog> (see client/css/dialog.css's #export-options-dialog)
+       instead of a popover like this one */
 	#volume-group {
 		position: relative;
 	}

--- a/client/css/dialog.css
+++ b/client/css/dialog.css
@@ -157,6 +157,18 @@
 		}
 	}
 
+	#gif-size-warning {
+		margin: 0;
+		text-align: center;
+		color: #ffcf7d;
+		font-family: sans-serif;
+		font-size: 13px;
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
 	#source-step,
 	#crop-step,
 	#edit-step {

--- a/client/css/dialog.css
+++ b/client/css/dialog.css
@@ -83,6 +83,67 @@
 		}
 	}
 
+	/* the pre-export options dialog — same transparent-host + blurred-backdrop
+       treatment as #preview-dialog/#export-progress-dialog above; declared
+       here for the same Biome-specificity-ordering reason noted on
+       #export-progress-dialog */
+	dialog#export-options-dialog {
+		border: none;
+		padding: 0;
+		background: transparent;
+
+		&::backdrop {
+			background: rgba(var(--color-void-rgb), 0.75);
+			backdrop-filter: blur(2px);
+		}
+	}
+
+	.export-options-card {
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 16px;
+		min-width: 280px;
+		padding: 28px 36px;
+		border: 1.5px solid rgba(var(--color-cyan-rgb), 0.4);
+		background: rgba(var(--color-void-rgb), 0.85);
+		backdrop-filter: blur(14px);
+		-webkit-backdrop-filter: blur(14px);
+		box-shadow:
+			0 20px 60px rgba(0, 0, 0, 0.5),
+			0 0 40px rgba(var(--color-magenta-rgb), 0.12);
+		clip-path: polygon(
+			20px 0,
+			100% 0,
+			100% calc(100% - 20px),
+			calc(100% - 20px) 100%,
+			0 100%,
+			0 20px
+		);
+
+		& > .tagline {
+			margin: 0;
+			text-align: center;
+			font-size: 18px;
+			color: var(--color-magenta-light);
+		}
+	}
+
+	.option-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		flex-wrap: wrap;
+	}
+
+	.option-label {
+		color: var(--color-chrome);
+		font-family: sans-serif;
+		font-size: 13px;
+		opacity: 0.8;
+	}
+
 	.slider-control {
 		display: flex;
 		align-items: center;
@@ -300,7 +361,8 @@
 		}
 
 		/* dismissive action: muted red border, fills solid red on hover */
-		#preview-cancel {
+		#preview-cancel,
+		#export-options-cancel {
 			border-color: rgba(122, 42, 42, 0.7);
 			color: #ff9d9d;
 

--- a/client/export-options.ts
+++ b/client/export-options.ts
@@ -1,0 +1,49 @@
+// Export option types/constants/logic shared between client/export.ts (the
+// pre-export options dialog) and server/export.ts (the renderer + query-param
+// validation) — lives in client/ and is imported across the boundary by
+// server/export.ts, the same way client/animation-timeline.ts already is.
+// Kept dependency-free (no DOM, no Node/Bun APIs) so it's safe both bundled
+// into the browser and run directly under Bun on the server. Centralized
+// here (rather than duplicated in both files) so the GIF caps/ordering and
+// the clamping logic itself can't drift out of sync between client and
+// server the way hand-copied constants eventually would.
+
+export type Orientation = "landscape" | "portrait";
+// 720p is the max tier: background.mp4 itself is authored at 1280x720, so a
+// 1080p export would just be upscaling the background for no real gain
+export type Resolution = "360p" | "480p" | "720p";
+export type FrameRate = 15 | 24 | 60;
+export type ExportFormat = "mp4" | "webm" | "gif";
+
+export const RESOLUTION_ORDER: Resolution[] = ["360p", "480p", "720p"];
+
+// GIF's palette-generation pass plus GIF's inherently poor compression for
+// video-like content make high resolution/framerate impractically slow and
+// huge: measured at ~146s/~324MB for 1080p/60fps, vs ~20s/~6MB for the same
+// settings as WebM. 720p is excluded entirely, but 360p/480p are both
+// allowed at full (unscaled) resolution — the client warns with a real size
+// estimate instead of the server silently capping resolution further.
+export const GIF_MAX_RESOLUTION: Resolution = "480p";
+export const GIF_MAX_FPS: FrameRate = 24;
+
+export function clampForGif(
+	resolution: Resolution,
+	fps: FrameRate,
+): { resolution: Resolution; fps: FrameRate } {
+	return {
+		resolution:
+			RESOLUTION_ORDER.indexOf(resolution) >
+			RESOLUTION_ORDER.indexOf(GIF_MAX_RESOLUTION)
+				? GIF_MAX_RESOLUTION
+				: resolution,
+		fps: fps > GIF_MAX_FPS ? GIF_MAX_FPS : fps,
+	};
+}
+
+// leaves room for ffmpeg's own post-last-frame encoding work (GIF's
+// palettegen/paletteuse pass especially) before jumping to a real 100% —
+// server/export.ts's renderFrames() caps per-frame progress here instead of
+// 100, then reports the real 100 once ffmpeg's process has actually exited;
+// client/export.ts's progress label swaps to "Finalizing…" in that gap
+// instead of sitting on a frozen percentage that reads as stuck/broken
+export const FRAME_PROGRESS_CAP = 95;

--- a/client/export.ts
+++ b/client/export.ts
@@ -162,8 +162,8 @@ export function initExport() {
 	exportBtn.addEventListener("click", () => {
 		if (exportBtn.disabled) return;
 
-		// default orientation is keyed off device type (mobile -> landscape,
-		// everything else -> portrait), not the current viewport orientation
+		// default orientation is keyed off device type (mobile -> portrait,
+		// everything else -> landscape), not the current viewport orientation
 		// — a deliberate product choice, still overridable in the dialog.
 		// Same isMobile check as preview.ts's source-step (hover:none +
 		// coarse pointer, without a fine pointer also present, to avoid
@@ -172,7 +172,7 @@ export function initExport() {
 		const isMobile =
 			window.matchMedia("(hover: none) and (pointer: coarse)").matches &&
 			!window.matchMedia("(any-pointer: fine)").matches;
-		selectOption(orientationGroup, isMobile ? "landscape" : "portrait");
+		selectOption(orientationGroup, isMobile ? "portrait" : "landscape");
 		selectOption(resolutionGroup, "480p");
 		selectOption(fpsGroup, "24");
 		selectOption(formatGroup, "mp4");

--- a/client/export.ts
+++ b/client/export.ts
@@ -3,12 +3,26 @@
 // browser, so this is fast enough that the progress dialog is only up for
 // roughly as long as the render + download take, not ~25s.
 
-// deliberately not imported from server/export.ts — this file keeps the
-// client/server type boundary hard-separated, same as elsewhere in client/
-type Orientation = "landscape" | "portrait";
-type Resolution = "360p" | "480p" | "720p";
-type FrameRate = 15 | 24 | 60;
-type ExportFormat = "mp4" | "webm" | "gif";
+// shared with server/export.ts (which imports the same file across the
+// client/server boundary, same as it already does for animation-timeline.ts)
+// so the option types, GIF caps/ordering, and the clamping logic itself
+// can't drift out of sync between the two — see export-options.ts
+import {
+	clampForGif,
+	type ExportFormat,
+	FRAME_PROGRESS_CAP,
+	type FrameRate,
+	GIF_MAX_FPS,
+	GIF_MAX_RESOLUTION,
+	type Orientation,
+	RESOLUTION_ORDER,
+	type Resolution,
+} from "./export-options";
+
+// dataset.value is always a plain string, even for the numeric FrameRate
+// options — this is the string-keyed form used for reading/writing DOM
+// attributes and building the size-estimate lookup key below
+type FrameRateValue = `${FrameRate}`;
 
 type ExportOptions = {
 	orientation: Orientation;
@@ -27,24 +41,14 @@ const DEFAULT_EXPORT_ERROR = "Couldn't export the animation. Please try again.";
 const EXPORT_ERROR_DISMISS_MS = 6000;
 const PROGRESS_POLL_MS = 200;
 
-// GIF's palette-generation pass + poor compression for video-like content
-// make high resolution/framerate impractically slow and huge (measured:
-// ~146s/~324MB for 1080p/60fps GIF vs ~20s/~6MB for the same settings as
-// WebM) — mirrors the server-side cap in server/export.ts's clampForGif(),
-// which is what actually enforces this; this is just the matching UI. GIF
-// renders at full (unscaled) resolution like every other format — no
-// automatic downscale — so 360p/480p are both genuinely large files; see
-// GIF_SIZE_ESTIMATE_MB below for the warning shown instead of shrinking them.
-const GIF_MAX_RESOLUTION: Resolution = "480p";
-const GIF_MAX_FPS: FrameRate = 24;
-const RESOLUTION_ORDER: Resolution[] = ["360p", "480p", "720p"];
-
 // real measured GIF sizes (full 256-color palette, bayer_scale=5 dither, no
 // resolution scale-down) — only the combinations GIF actually allows
 // (resolution capped to 480p, fps capped to 24) have entries. Orientation
 // doesn't change total pixel count (e.g. 640x360 vs 360x640), so one
 // estimate per resolution/fps pair covers both.
-const GIF_SIZE_ESTIMATE_MB: Record<string, number> = {
+const GIF_SIZE_ESTIMATE_MB: Partial<
+	Record<`${Resolution}:${FrameRateValue}`, number>
+> = {
 	"360p:15": 17,
 	"360p:24": 26,
 	"480p:15": 27,
@@ -52,18 +56,11 @@ const GIF_SIZE_ESTIMATE_MB: Record<string, number> = {
 };
 
 function estimateGifSizeMB(
-	resolution: string,
-	fps: string,
+	resolution: Resolution,
+	fps: FrameRateValue,
 ): number | undefined {
 	return GIF_SIZE_ESTIMATE_MB[`${resolution}:${fps}`];
 }
-
-// mirrors server/export.ts's FRAME_PROGRESS_CAP — ffmpeg's own post-last-
-// frame work (palette generation + encoding for GIF especially) keeps
-// running for a few real seconds after frame-piping progress tops out here,
-// so the label swaps to a "still working" message instead of sitting on a
-// frozen percentage that reads as stuck/broken
-const FRAME_PROGRESS_CAP = 95;
 
 export function initExport() {
 	const exportBtn = document.getElementById("export-btn") as HTMLButtonElement;
@@ -113,18 +110,21 @@ export function initExport() {
 	}
 
 	// generalizes the erase/pick tool-button aria-pressed toggling in
-	// transparency.ts from two fixed buttons to N data-driven ones per group
-	function selectOption(group: HTMLElement, value: string) {
+	// transparency.ts from two fixed buttons to N data-driven ones per group.
+	// Generic over the option-group's own value type (Orientation/Resolution/
+	// FrameRateValue/ExportFormat) so callers get a real typed value back
+	// instead of a bare string plus an `as` cast at every call site.
+	function selectOption<T extends string>(group: HTMLElement, value: T) {
 		for (const btn of group.querySelectorAll<HTMLButtonElement>("button")) {
 			btn.setAttribute("aria-pressed", String(btn.dataset.value === value));
 		}
 	}
 
-	function getSelected(group: HTMLElement): string {
+	function getSelected<T extends string>(group: HTMLElement): T {
 		const pressed = group.querySelector<HTMLButtonElement>(
 			'button[aria-pressed="true"]',
 		);
-		return pressed?.dataset.value ?? "";
+		return (pressed?.dataset.value ?? "") as T;
 	}
 
 	const resolutionGroup = optionsDialog.querySelector(
@@ -143,14 +143,14 @@ export function initExport() {
 	// GIF has no automatic size mitigation (see GIF_SIZE_ESTIMATE_MB above),
 	// so the warning is what tells the user up front instead of a silent cap
 	function updateGifWarning() {
-		const isGif = getSelected(formatGroup) === "gif";
+		const isGif = getSelected<ExportFormat>(formatGroup) === "gif";
 		if (!isGif) {
 			gifWarning.hidden = true;
 			return;
 		}
 		const estimate = estimateGifSizeMB(
-			getSelected(resolutionGroup),
-			getSelected(fpsGroup),
+			getSelected<Resolution>(resolutionGroup),
+			getSelected<FrameRateValue>(fpsGroup),
 		);
 		gifWarning.textContent =
 			estimate !== undefined
@@ -161,9 +161,11 @@ export function initExport() {
 
 	// disables the resolution/framerate options above the GIF cap when GIF
 	// is selected (falling back the current selection if it's now disabled),
-	// re-enables them otherwise
+	// re-enables them otherwise. The fallback reuses clampForGif — the same
+	// function server/export.ts's query-param validation enforces with — so
+	// the two can't disagree on what counts as "too high" for GIF.
 	function applyGifCap() {
-		const isGif = getSelected(formatGroup) === "gif";
+		const isGif = getSelected<ExportFormat>(formatGroup) === "gif";
 
 		for (const btn of resolutionGroup.querySelectorAll<HTMLButtonElement>(
 			"button",
@@ -178,15 +180,12 @@ export function initExport() {
 		}
 
 		if (isGif) {
-			if (
-				RESOLUTION_ORDER.indexOf(getSelected(resolutionGroup) as Resolution) >
-				RESOLUTION_ORDER.indexOf(GIF_MAX_RESOLUTION)
-			) {
-				selectOption(resolutionGroup, GIF_MAX_RESOLUTION);
-			}
-			if (Number(getSelected(fpsGroup)) > GIF_MAX_FPS) {
-				selectOption(fpsGroup, String(GIF_MAX_FPS));
-			}
+			const clamped = clampForGif(
+				getSelected<Resolution>(resolutionGroup),
+				Number(getSelected<FrameRateValue>(fpsGroup)) as FrameRate,
+			);
+			selectOption(resolutionGroup, clamped.resolution);
+			selectOption(fpsGroup, String(clamped.fps) as FrameRateValue);
 		}
 
 		updateGifWarning();
@@ -218,10 +217,13 @@ export function initExport() {
 		const isMobile =
 			window.matchMedia("(hover: none) and (pointer: coarse)").matches &&
 			!window.matchMedia("(any-pointer: fine)").matches;
-		selectOption(orientationGroup, isMobile ? "portrait" : "landscape");
-		selectOption(resolutionGroup, "480p");
-		selectOption(fpsGroup, "24");
-		selectOption(formatGroup, "mp4");
+		selectOption<Orientation>(
+			orientationGroup,
+			isMobile ? "portrait" : "landscape",
+		);
+		selectOption<Resolution>(resolutionGroup, "480p");
+		selectOption<FrameRateValue>(fpsGroup, "24");
+		selectOption<ExportFormat>(formatGroup, "mp4");
 		applyGifCap();
 
 		optionsDialog.showModal();
@@ -233,10 +235,10 @@ export function initExport() {
 
 	optionsStartBtn.addEventListener("click", () => {
 		const options: ExportOptions = {
-			orientation: getSelected(orientationGroup) as Orientation,
-			resolution: getSelected(resolutionGroup) as Resolution,
-			fps: Number(getSelected(fpsGroup)) as FrameRate,
-			format: getSelected(formatGroup) as ExportFormat,
+			orientation: getSelected<Orientation>(orientationGroup),
+			resolution: getSelected<Resolution>(resolutionGroup),
+			fps: Number(getSelected<FrameRateValue>(fpsGroup)) as FrameRate,
+			format: getSelected<ExportFormat>(formatGroup),
 		};
 		optionsDialog.close();
 		runExport(options);

--- a/client/export.ts
+++ b/client/export.ts
@@ -3,7 +3,19 @@
 // browser, so this is fast enough that the progress dialog is only up for
 // roughly as long as the render + download take, not ~25s.
 
-type ExportFormat = "mp4" | "webm";
+// deliberately not imported from server/export.ts — this file keeps the
+// client/server type boundary hard-separated, same as elsewhere in client/
+type Orientation = "landscape" | "portrait";
+type Resolution = "360p" | "480p" | "720p";
+type FrameRate = 15 | 24 | 60;
+type ExportFormat = "mp4" | "webm" | "gif";
+
+type ExportOptions = {
+	orientation: Orientation;
+	resolution: Resolution;
+	fps: FrameRate;
+	format: ExportFormat;
+};
 
 // keyed by the specific HTTP status server/server.ts's '/export/*' route can
 // return, so the user sees why it failed rather than one generic message
@@ -15,10 +27,37 @@ const DEFAULT_EXPORT_ERROR = "Couldn't export the animation. Please try again.";
 const EXPORT_ERROR_DISMISS_MS = 6000;
 const PROGRESS_POLL_MS = 200;
 
+// GIF's palette-generation pass + poor compression for video-like content
+// make high resolution/framerate impractically slow and huge (measured:
+// ~146s/~324MB for 1080p/60fps GIF vs ~20s/~6MB for the same settings as
+// WebM) — mirrors the server-side cap in server/export.ts's clampForGif(),
+// which is what actually enforces this; this is just the matching UI
+const GIF_MAX_RESOLUTION: Resolution = "360p";
+const GIF_MAX_FPS: FrameRate = 24;
+const RESOLUTION_ORDER: Resolution[] = ["360p", "480p", "720p"];
+
+// mirrors server/export.ts's FRAME_PROGRESS_CAP — ffmpeg's own post-last-
+// frame work (palette generation + encoding for GIF especially) keeps
+// running for a few real seconds after frame-piping progress tops out here,
+// so the label swaps to a "still working" message instead of sitting on a
+// frozen percentage that reads as stuck/broken
+const FRAME_PROGRESS_CAP = 95;
+
 export function initExport() {
-	const exportGroup = document.getElementById("export-group") as HTMLElement;
 	const exportBtn = document.getElementById("export-btn") as HTMLButtonElement;
-	const exportMenu = document.getElementById("export-menu") as HTMLElement;
+
+	const optionsDialog = document.getElementById(
+		"export-options-dialog",
+	) as HTMLDialogElement;
+	const optionsCancelBtn = document.getElementById(
+		"export-options-cancel",
+	) as HTMLButtonElement;
+	const optionsStartBtn = document.getElementById(
+		"export-options-start",
+	) as HTMLButtonElement;
+	const optionGroups = optionsDialog.querySelectorAll<HTMLElement>(
+		".option-row[data-option]",
+	);
 
 	const progressDialog = document.getElementById(
 		"export-progress-dialog",
@@ -51,34 +90,118 @@ export function initExport() {
 		}, EXPORT_ERROR_DISMISS_MS);
 	}
 
-	function setMenuOpen(open: boolean) {
-		exportMenu.hidden = !open;
-		exportBtn.setAttribute("aria-expanded", String(open));
+	// generalizes the erase/pick tool-button aria-pressed toggling in
+	// transparency.ts from two fixed buttons to N data-driven ones per group
+	function selectOption(group: HTMLElement, value: string) {
+		for (const btn of group.querySelectorAll<HTMLButtonElement>("button")) {
+			btn.setAttribute("aria-pressed", String(btn.dataset.value === value));
+		}
 	}
 
-	exportBtn.addEventListener("click", () => {
-		if (exportBtn.disabled) return;
-		setMenuOpen(!!exportMenu.hidden);
-	});
+	function getSelected(group: HTMLElement): string {
+		const pressed = group.querySelector<HTMLButtonElement>(
+			'button[aria-pressed="true"]',
+		);
+		return pressed?.dataset.value ?? "";
+	}
 
-	// closes the popover on any click outside the group, rather than wiring
-	// per-option blur handling
-	document.addEventListener("click", (e) => {
-		if (!exportGroup.contains(e.target as Node)) setMenuOpen(false);
-	});
+	const resolutionGroup = optionsDialog.querySelector(
+		'.option-row[data-option="resolution"]',
+	) as HTMLElement;
+	const fpsGroup = optionsDialog.querySelector(
+		'.option-row[data-option="fps"]',
+	) as HTMLElement;
+	const formatGroup = optionsDialog.querySelector(
+		'.option-row[data-option="format"]',
+	) as HTMLElement;
 
-	for (const option of exportMenu.querySelectorAll<HTMLButtonElement>(
-		".export-option",
-	)) {
-		option.addEventListener("click", () => {
-			setMenuOpen(false);
-			runExport(option.dataset.format as ExportFormat);
+	// disables the resolution/framerate options above the GIF cap when GIF
+	// is selected (falling back the current selection if it's now disabled),
+	// re-enables them otherwise
+	function applyGifCap() {
+		const isGif = getSelected(formatGroup) === "gif";
+
+		for (const btn of resolutionGroup.querySelectorAll<HTMLButtonElement>(
+			"button",
+		)) {
+			btn.disabled =
+				isGif &&
+				RESOLUTION_ORDER.indexOf(btn.dataset.value as Resolution) >
+					RESOLUTION_ORDER.indexOf(GIF_MAX_RESOLUTION);
+		}
+		for (const btn of fpsGroup.querySelectorAll<HTMLButtonElement>("button")) {
+			btn.disabled = isGif && Number(btn.dataset.value) > GIF_MAX_FPS;
+		}
+
+		if (isGif) {
+			if (
+				RESOLUTION_ORDER.indexOf(getSelected(resolutionGroup) as Resolution) >
+				RESOLUTION_ORDER.indexOf(GIF_MAX_RESOLUTION)
+			) {
+				selectOption(resolutionGroup, GIF_MAX_RESOLUTION);
+			}
+			if (Number(getSelected(fpsGroup)) > GIF_MAX_FPS) {
+				selectOption(fpsGroup, String(GIF_MAX_FPS));
+			}
+		}
+	}
+
+	for (const group of optionGroups) {
+		group.querySelector(".tool-picker")?.addEventListener("click", (e) => {
+			const btn = (e.target as HTMLElement).closest("button");
+			if (!btn || btn.disabled) return;
+			selectOption(group, btn.dataset.value ?? "");
+			if (group === formatGroup) applyGifCap();
 		});
 	}
 
+	const orientationGroup = optionsDialog.querySelector(
+		'.option-row[data-option="orientation"]',
+	) as HTMLElement;
+
+	exportBtn.addEventListener("click", () => {
+		if (exportBtn.disabled) return;
+
+		// default orientation is keyed off device type (mobile -> landscape,
+		// everything else -> portrait), not the current viewport orientation
+		// — a deliberate product choice, still overridable in the dialog.
+		// Same isMobile check as preview.ts's source-step (hover:none +
+		// coarse pointer, without a fine pointer also present, to avoid
+		// misclassifying a touchscreen laptop/tablet that also has a
+		// mouse/trackpad attached).
+		const isMobile =
+			window.matchMedia("(hover: none) and (pointer: coarse)").matches &&
+			!window.matchMedia("(any-pointer: fine)").matches;
+		selectOption(orientationGroup, isMobile ? "landscape" : "portrait");
+		selectOption(resolutionGroup, "480p");
+		selectOption(fpsGroup, "24");
+		selectOption(formatGroup, "mp4");
+		applyGifCap();
+
+		optionsDialog.showModal();
+	});
+
+	optionsCancelBtn.addEventListener("click", () => {
+		optionsDialog.close();
+	});
+
+	optionsStartBtn.addEventListener("click", () => {
+		const options: ExportOptions = {
+			orientation: getSelected(orientationGroup) as Orientation,
+			resolution: getSelected(resolutionGroup) as Resolution,
+			fps: Number(getSelected(fpsGroup)) as FrameRate,
+			format: getSelected(formatGroup) as ExportFormat,
+		};
+		optionsDialog.close();
+		runExport(options);
+	});
+
 	function setProgress(percent: number) {
 		progressBar.value = percent;
-		progressLabel.textContent = `${percent}%`;
+		progressLabel.textContent =
+			percent >= FRAME_PROGRESS_CAP && percent < 100
+				? "Finalizing…"
+				: `${percent}%`;
 	}
 
 	async function pollProgress(): Promise<void> {
@@ -91,7 +214,12 @@ export function initExport() {
 		}
 	}
 
-	async function runExport(format: ExportFormat) {
+	async function runExport({
+		orientation,
+		resolution,
+		fps,
+		format,
+	}: ExportOptions) {
 		exportBtn.disabled = true;
 		setProgress(0);
 		// showModal() makes the rest of the page inert on its own — nothing
@@ -101,13 +229,10 @@ export function initExport() {
 
 		const hash =
 			window.location.pathname !== "/" ? window.location.pathname.slice(1) : "";
-		const orientation = window.matchMedia("(orientation: portrait)").matches
-			? "portrait"
-			: "landscape";
 
 		try {
 			const res = await fetch(
-				`/export/${hash}?orientation=${orientation}&format=${format}`,
+				`/export/${hash}?orientation=${orientation}&resolution=${resolution}&fps=${fps}&format=${format}`,
 			);
 			if (!res.ok) {
 				showError(EXPORT_ERROR_MESSAGES[res.status] ?? DEFAULT_EXPORT_ERROR);

--- a/client/export.ts
+++ b/client/export.ts
@@ -31,23 +31,31 @@ const PROGRESS_POLL_MS = 200;
 // make high resolution/framerate impractically slow and huge (measured:
 // ~146s/~324MB for 1080p/60fps GIF vs ~20s/~6MB for the same settings as
 // WebM) — mirrors the server-side cap in server/export.ts's clampForGif(),
-// which is what actually enforces this; this is just the matching UI
-const GIF_MAX_RESOLUTION: Resolution = "360p";
+// which is what actually enforces this; this is just the matching UI. GIF
+// renders at full (unscaled) resolution like every other format — no
+// automatic downscale — so 360p/480p are both genuinely large files; see
+// GIF_SIZE_ESTIMATE_MB below for the warning shown instead of shrinking them.
+const GIF_MAX_RESOLUTION: Resolution = "480p";
 const GIF_MAX_FPS: FrameRate = 24;
 const RESOLUTION_ORDER: Resolution[] = ["360p", "480p", "720p"];
 
-// mirrors server/export.ts's GIF_SCALE_FACTOR — GIF downscales the
-// composited frame by this much right before the palette/encode stage (to
-// keep file size down without cutting the color palette), so the actual
-// GIF pixel dimensions are smaller than the chosen resolution tier's own
-// label suggests (e.g. "360p" -> an actual 320x180/180p output). The
-// resolution buttons' labels are swapped to reflect the true output size
-// whenever GIF is selected, rather than silently showing a number that
-// doesn't match what comes out.
-const GIF_SCALE_FACTOR = 0.5;
+// real measured GIF sizes (full 256-color palette, bayer_scale=5 dither, no
+// resolution scale-down) — only the combinations GIF actually allows
+// (resolution capped to 480p, fps capped to 24) have entries. Orientation
+// doesn't change total pixel count (e.g. 640x360 vs 360x640), so one
+// estimate per resolution/fps pair covers both.
+const GIF_SIZE_ESTIMATE_MB: Record<string, number> = {
+	"360p:15": 17,
+	"360p:24": 26,
+	"480p:15": 27,
+	"480p:24": 42,
+};
 
-function gifEffectiveLabel(resolution: string): string {
-	return `${Math.round(Number.parseInt(resolution, 10) * GIF_SCALE_FACTOR)}p`;
+function estimateGifSizeMB(
+	resolution: string,
+	fps: string,
+): number | undefined {
+	return GIF_SIZE_ESTIMATE_MB[`${resolution}:${fps}`];
 }
 
 // mirrors server/export.ts's FRAME_PROGRESS_CAP — ffmpeg's own post-last-
@@ -129,22 +137,41 @@ export function initExport() {
 		'.option-row[data-option="format"]',
 	) as HTMLElement;
 
+	const gifWarning = document.getElementById("gif-size-warning") as HTMLElement;
+
+	// shows a real size estimate whenever GIF is selected — full-resolution
+	// GIF has no automatic size mitigation (see GIF_SIZE_ESTIMATE_MB above),
+	// so the warning is what tells the user up front instead of a silent cap
+	function updateGifWarning() {
+		const isGif = getSelected(formatGroup) === "gif";
+		if (!isGif) {
+			gifWarning.hidden = true;
+			return;
+		}
+		const estimate = estimateGifSizeMB(
+			getSelected(resolutionGroup),
+			getSelected(fpsGroup),
+		);
+		gifWarning.textContent =
+			estimate !== undefined
+				? `⚠️ GIF at this resolution/framerate will be a large file — roughly ${estimate}MB.`
+				: "⚠️ GIF exports produce large files.";
+		gifWarning.hidden = false;
+	}
+
 	// disables the resolution/framerate options above the GIF cap when GIF
 	// is selected (falling back the current selection if it's now disabled),
-	// re-enables them otherwise. Also relabels resolution buttons to their
-	// true GIF output size (see GIF_SCALE_FACTOR above) while GIF is active.
+	// re-enables them otherwise
 	function applyGifCap() {
 		const isGif = getSelected(formatGroup) === "gif";
 
 		for (const btn of resolutionGroup.querySelectorAll<HTMLButtonElement>(
 			"button",
 		)) {
-			const value = btn.dataset.value ?? "";
 			btn.disabled =
 				isGif &&
-				RESOLUTION_ORDER.indexOf(value as Resolution) >
+				RESOLUTION_ORDER.indexOf(btn.dataset.value as Resolution) >
 					RESOLUTION_ORDER.indexOf(GIF_MAX_RESOLUTION);
-			btn.textContent = isGif ? gifEffectiveLabel(value) : value;
 		}
 		for (const btn of fpsGroup.querySelectorAll<HTMLButtonElement>("button")) {
 			btn.disabled = isGif && Number(btn.dataset.value) > GIF_MAX_FPS;
@@ -161,6 +188,8 @@ export function initExport() {
 				selectOption(fpsGroup, String(GIF_MAX_FPS));
 			}
 		}
+
+		updateGifWarning();
 	}
 
 	for (const group of optionGroups) {
@@ -168,7 +197,7 @@ export function initExport() {
 			const btn = (e.target as HTMLElement).closest("button");
 			if (!btn || btn.disabled) return;
 			selectOption(group, btn.dataset.value ?? "");
-			if (group === formatGroup) applyGifCap();
+			applyGifCap();
 		});
 	}
 

--- a/client/export.ts
+++ b/client/export.ts
@@ -36,6 +36,20 @@ const GIF_MAX_RESOLUTION: Resolution = "360p";
 const GIF_MAX_FPS: FrameRate = 24;
 const RESOLUTION_ORDER: Resolution[] = ["360p", "480p", "720p"];
 
+// mirrors server/export.ts's GIF_SCALE_FACTOR — GIF downscales the
+// composited frame by this much right before the palette/encode stage (to
+// keep file size down without cutting the color palette), so the actual
+// GIF pixel dimensions are smaller than the chosen resolution tier's own
+// label suggests (e.g. "360p" -> an actual 320x180/180p output). The
+// resolution buttons' labels are swapped to reflect the true output size
+// whenever GIF is selected, rather than silently showing a number that
+// doesn't match what comes out.
+const GIF_SCALE_FACTOR = 0.5;
+
+function gifEffectiveLabel(resolution: string): string {
+	return `${Math.round(Number.parseInt(resolution, 10) * GIF_SCALE_FACTOR)}p`;
+}
+
 // mirrors server/export.ts's FRAME_PROGRESS_CAP — ffmpeg's own post-last-
 // frame work (palette generation + encoding for GIF especially) keeps
 // running for a few real seconds after frame-piping progress tops out here,
@@ -117,17 +131,20 @@ export function initExport() {
 
 	// disables the resolution/framerate options above the GIF cap when GIF
 	// is selected (falling back the current selection if it's now disabled),
-	// re-enables them otherwise
+	// re-enables them otherwise. Also relabels resolution buttons to their
+	// true GIF output size (see GIF_SCALE_FACTOR above) while GIF is active.
 	function applyGifCap() {
 		const isGif = getSelected(formatGroup) === "gif";
 
 		for (const btn of resolutionGroup.querySelectorAll<HTMLButtonElement>(
 			"button",
 		)) {
+			const value = btn.dataset.value ?? "";
 			btn.disabled =
 				isGif &&
-				RESOLUTION_ORDER.indexOf(btn.dataset.value as Resolution) >
+				RESOLUTION_ORDER.indexOf(value as Resolution) >
 					RESOLUTION_ORDER.indexOf(GIF_MAX_RESOLUTION);
+			btn.textContent = isGif ? gifEffectiveLabel(value) : value;
 		}
 		for (const btn of fpsGroup.querySelectorAll<HTMLButtonElement>("button")) {
 			btn.disabled = isGif && Number(btn.dataset.value) > GIF_MAX_FPS;

--- a/client/index.html
+++ b/client/index.html
@@ -136,6 +136,7 @@
                         <button type="button" data-value="gif" aria-pressed="false">🖼️ GIF</button>
                     </div>
                 </div>
+                <p id="gif-size-warning" role="alert" hidden></p>
                 <div class="preview-actions">
                     <button id="export-options-cancel" type="button">✕ Cancel</button>
                     <button id="export-options-start" type="button">✦ Start export ✦</button>

--- a/client/index.html
+++ b/client/index.html
@@ -25,13 +25,7 @@
         </form>
         <div id="quick-actions">
             <button type="button" class="dock-btn upload-trigger" title="Upload your pic" aria-label="Upload your pic">📤</button>
-            <div id="export-group">
-                <button type="button" id="export-btn" class="dock-btn" title="Export as video" aria-label="Export as video" aria-haspopup="true" aria-expanded="false">💾</button>
-                <div id="export-menu" hidden>
-                    <button type="button" class="export-option" data-format="mp4">🎬 MP4</button>
-                    <button type="button" class="export-option" data-format="webm">🎬 WebM</button>
-                </div>
-            </div>
+            <button type="button" id="export-btn" class="dock-btn" title="Export" aria-label="Export">💾</button>
             <div id="volume-group">
                 <button type="button" id="volume-btn" class="dock-btn" title="Volume" aria-label="Volume" aria-haspopup="true" aria-expanded="false">🔊</button>
                 <div id="volume-menu" hidden>
@@ -105,6 +99,46 @@
                     <button id="edit-back" type="button" hidden>⬅ Back</button>
                     <button id="crop-next" type="button" hidden>Next ➔</button>
                     <button id="preview-confirm" type="button" hidden>✦ Upload ✦</button>
+                </div>
+            </div>
+        </dialog>
+        <dialog id="export-options-dialog">
+            <div class="export-options-card">
+                <p class="tagline">✦ Export options ✦</p>
+                <div class="option-row" data-option="orientation">
+                    <span class="option-label">Orientation</span>
+                    <div class="tool-picker">
+                        <button type="button" data-value="landscape" aria-pressed="true">Landscape</button>
+                        <button type="button" data-value="portrait" aria-pressed="false">Portrait</button>
+                    </div>
+                </div>
+                <div class="option-row" data-option="resolution">
+                    <span class="option-label">Resolution</span>
+                    <div class="tool-picker">
+                        <button type="button" data-value="360p" aria-pressed="false">360p</button>
+                        <button type="button" data-value="480p" aria-pressed="true">480p</button>
+                        <button type="button" data-value="720p" aria-pressed="false">720p</button>
+                    </div>
+                </div>
+                <div class="option-row" data-option="fps">
+                    <span class="option-label">Framerate</span>
+                    <div class="tool-picker">
+                        <button type="button" data-value="15" aria-pressed="false">15 fps</button>
+                        <button type="button" data-value="24" aria-pressed="true">24 fps</button>
+                        <button type="button" data-value="60" aria-pressed="false">60 fps</button>
+                    </div>
+                </div>
+                <div class="option-row" data-option="format">
+                    <span class="option-label">Format</span>
+                    <div class="tool-picker">
+                        <button type="button" data-value="mp4" aria-pressed="true">🎬 MP4</button>
+                        <button type="button" data-value="webm" aria-pressed="false">🎬 WebM</button>
+                        <button type="button" data-value="gif" aria-pressed="false">🖼️ GIF</button>
+                    </div>
+                </div>
+                <div class="preview-actions">
+                    <button id="export-options-cancel" type="button">✕ Cancel</button>
+                    <button id="export-options-start" type="button">✦ Start export ✦</button>
                 </div>
             </div>
         </dialog>

--- a/server/export-worker.ts
+++ b/server/export-worker.ts
@@ -8,12 +8,15 @@ import { parentPort, workerData } from "node:worker_threads";
 import type { ExportJob } from "./export";
 import { renderExport } from "./export";
 
-const { imagePath, orientation, format, dir } = workerData as ExportJob;
+const { imagePath, orientation, resolution, fps, format, dir } =
+	workerData as ExportJob;
 
 try {
 	const outputPath = await renderExport(
 		imagePath,
 		orientation,
+		resolution,
+		fps,
 		format,
 		dir,
 		(percent) => {

--- a/server/export.ts
+++ b/server/export.ts
@@ -17,14 +17,67 @@ import {
 import { ANIMATIONS, resolvePictureFrame } from "./keyframes";
 
 export type Orientation = "landscape" | "portrait";
-export type ExportFormat = "mp4" | "webm";
+// 720p is the max tier: background.mp4 itself is authored at 1280x720, so a
+// 1080p export would just be upscaling the background for no real gain
+export type Resolution = "360p" | "480p" | "720p";
+export type FrameRate = 15 | 24 | 60;
+export type ExportFormat = "mp4" | "webm" | "gif";
 
-// 480p — smaller than the source background.mp4 (1280x720), traded for
-// faster encodes; bgFilter below scales the source down to match regardless
-// of orientation, not just when cropping portrait
-const VIEWPORTS: Record<Orientation, { width: number; height: number }> = {
-	landscape: { width: 854, height: 480 },
-	portrait: { width: 480, height: 854 },
+export const ORIENTATIONS: Orientation[] = ["landscape", "portrait"];
+export const RESOLUTIONS: Resolution[] = ["360p", "480p", "720p"];
+export const FRAME_RATES: FrameRate[] = [15, 24, 60];
+export const EXPORT_FORMATS: ExportFormat[] = ["mp4", "webm", "gif"];
+
+export const DEFAULT_ORIENTATION: Orientation = "landscape";
+export const DEFAULT_RESOLUTION: Resolution = "480p";
+export const DEFAULT_FPS: FrameRate = 24;
+export const DEFAULT_FORMAT: ExportFormat = "mp4";
+
+// GIF's palette-generation pass plus GIF's inherently poor compression for
+// video-like content make high resolution/framerate impractically slow and
+// huge: measured at ~146s/~324MB for 1080p/60fps, vs ~20s/~6MB for the same
+// settings as WebM. Clamping GIF down keeps one format from blowing the
+// render-time budget every other export relies on. 360p/24fps was measured
+// at ~16.5s/~39MB — still the biggest file of any capped combination, but
+// comfortably within the render-time budget.
+export const GIF_MAX_RESOLUTION: Resolution = "360p";
+export const GIF_MAX_FPS: FrameRate = 24;
+
+const RESOLUTION_ORDER: Resolution[] = ["360p", "480p", "720p"];
+
+export function clampForGif(
+	resolution: Resolution,
+	fps: FrameRate,
+): { resolution: Resolution; fps: FrameRate } {
+	return {
+		resolution:
+			RESOLUTION_ORDER.indexOf(resolution) >
+			RESOLUTION_ORDER.indexOf(GIF_MAX_RESOLUTION)
+				? GIF_MAX_RESOLUTION
+				: resolution,
+		fps: fps > GIF_MAX_FPS ? GIF_MAX_FPS : fps,
+	};
+}
+
+// 480p is the original/default tier — kept unchanged from before resolution
+// was configurable, for continuity with any bookmarked/shared export
+// behavior. Every tier matches the export viewport's own aspect ratio
+// (16:9 landscape / 9:16 portrait); bgFilter below always scales+crops the
+// background down/up to match, regardless of orientation or tier.
+const VIEWPORTS: Record<
+	Orientation,
+	Record<Resolution, { width: number; height: number }>
+> = {
+	landscape: {
+		"360p": { width: 640, height: 360 },
+		"480p": { width: 854, height: 480 },
+		"720p": { width: 1280, height: 720 },
+	},
+	portrait: {
+		"360p": { width: 360, height: 640 },
+		"480p": { width: 480, height: 854 },
+		"720p": { width: 720, height: 1280 },
+	},
 };
 
 // matches base.css's `--travel-scale: clamp(0.25, calc(100vw / 1400px), 1)`
@@ -46,8 +99,6 @@ function pictureBox(
 		height: (viewport.height * 0.3) / scale,
 	};
 }
-
-const FPS = 24;
 
 // the last ANIMATION_TIMELINE offset is the loop point (stage swaps back
 // to "init", matching the background video's own length / 'ended' event)
@@ -73,6 +124,10 @@ function findStage(timeMs: number) {
 	return active;
 }
 
+// leaves room for ffmpeg's own post-last-frame encoding work (see the
+// onProgress call in renderFrames below) before jumping to a real 100%
+const FRAME_PROGRESS_CAP = 95;
+
 function cssFilterString(filter: {
 	kind: "none" | "saturate" | "contrast";
 	amount: number;
@@ -84,10 +139,12 @@ function cssFilterString(filter: {
 async function renderFrames(
 	imagePath: string,
 	orientation: Orientation,
+	resolution: Resolution,
+	fps: FrameRate,
 	onFrame: (buffer: Buffer) => Promise<void> | void,
 	onProgress?: (percent: number) => void,
 ): Promise<void> {
-	const viewport = VIEWPORTS[orientation];
+	const viewport = VIEWPORTS[orientation][resolution];
 	const scale = travelScale(viewport.width);
 	const box = pictureBox(viewport, scale);
 
@@ -103,9 +160,9 @@ async function renderFrames(
 	const canvas = createCanvas(viewport.width, viewport.height);
 	const ctx = canvas.getContext("2d");
 
-	const totalFrames = Math.ceil((EXPORT_DURATION_MS / 1000) * FPS);
+	const totalFrames = Math.ceil((EXPORT_DURATION_MS / 1000) * fps);
 	for (let n = 0; n < totalFrames; n++) {
-		const frameTimeMs = (n * 1000) / FPS;
+		const frameTimeMs = (n * 1000) / fps;
 		const stage = findStage(frameTimeMs);
 		const elapsed = frameTimeMs - stage.startMs;
 
@@ -158,8 +215,14 @@ async function renderFrames(
 		// frames are piped into ffmpeg as they're generated (not rendered
 		// up front then encoded in a second pass), so "frames sent so far"
 		// tracks real encode progress closely enough — no need to parse
-		// ffmpeg's own stderr progress output for this
-		onProgress?.(Math.round(((n + 1) / totalFrames) * 100));
+		// ffmpeg's own stderr progress output for this. Capped below 100
+		// (not a full 0-100 scale) since ffmpeg still has to finish encoding
+		// after the last frame is piped in — GIF's palettegen/paletteuse pass
+		// in particular keeps running well after every frame has arrived, so
+		// hitting 100% here would leave the UI stuck at "100%" for that whole
+		// remaining stretch. renderExport() emits the real 100% once ffmpeg's
+		// process has actually exited.
+		onProgress?.(Math.round(((n + 1) / totalFrames) * FRAME_PROGRESS_CAP));
 	}
 }
 
@@ -189,7 +252,7 @@ const backgroundVideoPath = `${import.meta.dir}/../client/public/videos/backgrou
 // MP4 output (same container family), but WebM can't carry AAC at all —
 // vorbis is the traditional, always-available WebM audio codec, so that
 // format re-encodes instead of copying.
-const ENCODE_ARGS: Record<string, string[]> = {
+const ENCODE_ARGS: Record<"mp4" | "webm", string[]> = {
 	mp4: ["-c:a", "copy", "-c:v", "libx264", "-preset", "ultrafast"],
 	webm: [
 		"-c:a",
@@ -210,19 +273,71 @@ const ENCODE_ARGS: Record<string, string[]> = {
 export async function renderExport(
 	imagePath: string,
 	orientation: Orientation,
+	resolution: Resolution,
+	fps: FrameRate,
 	format: ExportFormat,
 	dir: string,
 	onProgress?: (percent: number) => void,
 ): Promise<string> {
-	const viewport = VIEWPORTS[orientation];
+	const viewport = VIEWPORTS[orientation][resolution];
 	const outPath = join(dir, `export.${format}`);
 
-	// cover-crops the source background.mp4 (1280x720) down to the export's
-	// viewport — for portrait this also reshapes the aspect ratio, matching
-	// the CSS `min-width/min-height: 100%` "cover" sizing the <video> gets
-	// in the browser; for landscape it's just a downscale to 480p (16:9
-	// already matches, so the crop is a no-op)
-	const bgFilter = `scale=${viewport.width}:${viewport.height}:force_original_aspect_ratio=increase,crop=${viewport.width}:${viewport.height}`;
+	// cover-crops the source background.mp4 (1280x720) down/up to the
+	// export's viewport — for portrait this also reshapes the aspect ratio,
+	// matching the CSS `min-width/min-height: 100%` "cover" sizing the
+	// <video> gets in the browser; for landscape it's just a scale (16:9
+	// already matches every landscape tier, so the crop is a no-op). The
+	// trailing fps filter resamples the background from its own native
+	// ~23.976fps up (or down) to our chosen fps *before* the overlay filter
+	// runs — without it, overlay's output cadence is driven by its *main*
+	// ([0:v], the background) input, so at fps=60 it would still only
+	// sample our 60fps picture-overlay stream ~24 times/sec (confirmed by
+	// testing: framemd5 showed heavy frame duplication, one identical frame
+	// repeated 331 times, at 60fps before this fix) — the picture motion
+	// itself needs the *main* input resampled to the target rate so overlay
+	// actually consumes a distinct overlay frame every output frame.
+	const bgFilter = `scale=${viewport.width}:${viewport.height}:force_original_aspect_ratio=increase,crop=${viewport.width}:${viewport.height},fps=${fps}`;
+
+	// GIF has no audio track and needs a palette pass for reasonable
+	// quality (ffmpeg's default GIF encoder without one looks banded/dithered
+	// badly), so its filter graph/map/tail genuinely diverge from mp4/webm
+	// rather than fitting the same fixed shape. paletteuse's default dither
+	// (sierra2_4a, an error-diffusion algorithm) produces essentially random
+	// per-frame noise that both looks worse and compresses worse than an
+	// ordered (Bayer) dither for this kind of content — measured ~29%
+	// smaller (25.4MB -> 18.1MB at 360p/15fps) with no visible quality
+	// difference at bayer_scale=5 (the coarsest/most size-efficient setting)
+	// vs the default. On top of that, capping the palette to 40 colors
+	// (default is 256) was measured at ~9.5MB at the same settings — a
+	// deliberate quality/size trade-off (visible banding on gradients,
+	// requested and accepted) to land GIF exports in the 5-10MB range
+	// instead of ~18MB. Both measurements confirmed by pixel-comparing
+	// extracted frames, not just file size.
+	const filterComplex =
+		format === "gif"
+			? `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp];[comp]split[a][b];[a]palettegen=max_colors=40[pal];[b][pal]paletteuse=dither=bayer:bayer_scale=5[out]`
+			: `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp]`;
+
+	const mapArgs =
+		format === "gif" ? ["-map", "[out]"] : ["-map", "[comp]", "-map", "0:a?"];
+
+	// forces the actual encoded output to our chosen fps — without this,
+	// the muxer just inherits the filter graph's natural framerate (the
+	// *main* input to the overlay filter, i.e. background.mp4's own native
+	// ~23.976fps), silently ignoring whatever fps the rawvideo input above
+	// was piped at. Confirmed by testing: omitting this made every fps
+	// choice other than 24 (background.mp4's own rate, rounded) have no
+	// visible effect at all.
+	const outputFpsArgs = ["-r", `${fps}`];
+
+	// "-shortest"/"-pix_fmt yuv420p" only make sense for the audio-bearing,
+	// yuv-encoded video formats — gif has neither an audio track to trim nor
+	// a yuv pixel format, and ffmpeg picks the gif muxer from outPath's
+	// extension on its own, same as it already does for mp4/webm
+	const tailArgs =
+		format === "gif"
+			? []
+			: [...ENCODE_ARGS[format], "-shortest", "-pix_fmt", "yuv420p"];
 
 	await runFfmpeg(
 		[
@@ -235,28 +350,33 @@ export async function renderExport(
 			"-s",
 			`${viewport.width}x${viewport.height}`,
 			"-r",
-			`${FPS}`,
+			`${fps}`,
 			"-i",
 			"pipe:0",
 			"-filter_complex",
-			`[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp]`,
-			"-map",
-			"[comp]",
-			// "-shortest" trims the (possibly re-encoded) audio track to match
-			// the rendered video length so it doesn't play on past the last frame
-			"-map",
-			"0:a?",
-			...ENCODE_ARGS[format],
-			"-shortest",
-			"-pix_fmt",
-			"yuv420p",
+			filterComplex,
+			...mapArgs,
+			...outputFpsArgs,
+			...tailArgs,
 			"-y",
 			outPath,
 		],
 		async (write) => {
-			await renderFrames(imagePath, orientation, write, onProgress);
+			await renderFrames(
+				imagePath,
+				orientation,
+				resolution,
+				fps,
+				write,
+				onProgress,
+			);
 		},
 	);
+
+	// the frame-loop progress above tops out at FRAME_PROGRESS_CAP, not 100 —
+	// this is the real 100%, only reported once ffmpeg has actually finished
+	// (encoding/palette work can run well after the last frame was piped in)
+	onProgress?.(100);
 
 	return outPath;
 }
@@ -264,6 +384,8 @@ export async function renderExport(
 export type ExportJob = {
 	imagePath: string;
 	orientation: Orientation;
+	resolution: Resolution;
+	fps: FrameRate;
 	format: ExportFormat;
 	dir: string;
 };

--- a/server/export.ts
+++ b/server/export.ts
@@ -14,14 +14,21 @@ import {
 	ANIMATION_TIMELINE,
 	pictureAnimationKey,
 } from "../client/animation-timeline";
+// re-exported below (via `export *`) so server.ts/export-worker.ts's
+// existing `from "./export"` imports don't need to change — this file
+// stays the single import point for server-side export code, it just
+// sources the option types/GIF caps/clamping logic from client/ now
+// instead of defining its own copy (see export-options.ts for why)
+import {
+	type ExportFormat,
+	FRAME_PROGRESS_CAP,
+	type FrameRate,
+	type Orientation,
+	type Resolution,
+} from "../client/export-options";
 import { ANIMATIONS, resolvePictureFrame } from "./keyframes";
 
-export type Orientation = "landscape" | "portrait";
-// 720p is the max tier: background.mp4 itself is authored at 1280x720, so a
-// 1080p export would just be upscaling the background for no real gain
-export type Resolution = "360p" | "480p" | "720p";
-export type FrameRate = 15 | 24 | 60;
-export type ExportFormat = "mp4" | "webm" | "gif";
+export * from "../client/export-options";
 
 export const ORIENTATIONS: Orientation[] = ["landscape", "portrait"];
 export const RESOLUTIONS: Resolution[] = ["360p", "480p", "720p"];
@@ -32,33 +39,6 @@ export const DEFAULT_ORIENTATION: Orientation = "landscape";
 export const DEFAULT_RESOLUTION: Resolution = "480p";
 export const DEFAULT_FPS: FrameRate = 24;
 export const DEFAULT_FORMAT: ExportFormat = "mp4";
-
-// GIF's palette-generation pass plus GIF's inherently poor compression for
-// video-like content make high resolution/framerate impractically slow and
-// huge: measured at ~146s/~324MB for 1080p/60fps, vs ~20s/~6MB for the same
-// settings as WebM. Clamping GIF down keeps one format from blowing the
-// render-time budget every other export relies on — 720p is excluded, but
-// 360p/480p are both allowed at full (unscaled) resolution: the client
-// warns with a real size estimate before the user commits to one of these,
-// rather than silently capping resolution further the way fps still is.
-export const GIF_MAX_RESOLUTION: Resolution = "480p";
-export const GIF_MAX_FPS: FrameRate = 24;
-
-const RESOLUTION_ORDER: Resolution[] = ["360p", "480p", "720p"];
-
-export function clampForGif(
-	resolution: Resolution,
-	fps: FrameRate,
-): { resolution: Resolution; fps: FrameRate } {
-	return {
-		resolution:
-			RESOLUTION_ORDER.indexOf(resolution) >
-			RESOLUTION_ORDER.indexOf(GIF_MAX_RESOLUTION)
-				? GIF_MAX_RESOLUTION
-				: resolution,
-		fps: fps > GIF_MAX_FPS ? GIF_MAX_FPS : fps,
-	};
-}
 
 // 480p is the original/default tier — kept unchanged from before resolution
 // was configurable, for continuity with any bookmarked/shared export
@@ -124,10 +104,6 @@ function findStage(timeMs: number) {
 	}
 	return active;
 }
-
-// leaves room for ffmpeg's own post-last-frame encoding work (see the
-// onProgress call in renderFrames below) before jumping to a real 100%
-const FRAME_PROGRESS_CAP = 95;
 
 function cssFilterString(filter: {
 	kind: "none" | "saturate" | "contrast";

--- a/server/export.ts
+++ b/server/export.ts
@@ -320,10 +320,12 @@ export async function renderExport(
 	// without reducing color count or introducing dithering artifacts.
 	// Rendering at full resolution and downscaling afterwards also looks
 	// better than natively rendering smaller would (closer to supersampling)
-	// — confirmed by pixel-comparing extracted frames: no visible banding,
-	// unlike the max_colors approach. Measured ~8.9MB at 360p/15fps (down
-	// from ~18.1MB unscaled), comfortably inside a 5-10MB target.
-	const GIF_SCALE_FACTOR = 2 / 3;
+	// — confirmed by pixel-comparing extracted frames: no visible banding at
+	// any factor tested down to 0.45. 0.5 (an even half-resolution downscale,
+	// e.g. 640x360 -> 320x180) was measured at ~8.2MB at 360p/24fps (GIF's
+	// max framerate, the worst case for size) and ~5MB at 360p/15fps —
+	// comfortably inside a 5-8MB target across GIF's whole fps range.
+	const GIF_SCALE_FACTOR = 0.5;
 	const filterComplex =
 		format === "gif"
 			? `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp];[comp]scale=iw*${GIF_SCALE_FACTOR}:ih*${GIF_SCALE_FACTOR}[small];[small]split[a][b];[a]palettegen[pal];[b][pal]paletteuse=dither=bayer:bayer_scale=5[out]`

--- a/server/export.ts
+++ b/server/export.ts
@@ -307,15 +307,26 @@ export async function renderExport(
 	// ordered (Bayer) dither for this kind of content — measured ~29%
 	// smaller (25.4MB -> 18.1MB at 360p/15fps) with no visible quality
 	// difference at bayer_scale=5 (the coarsest/most size-efficient setting)
-	// vs the default. On top of that, capping the palette to 40 colors
-	// (default is 256) was measured at ~9.5MB at the same settings — a
-	// deliberate quality/size trade-off (visible banding on gradients,
-	// requested and accepted) to land GIF exports in the 5-10MB range
-	// instead of ~18MB. Both measurements confirmed by pixel-comparing
-	// extracted frames, not just file size.
+	// vs the default. The full 256-color palette (palettegen's default) is
+	// kept as-is — capping max_colors was tried and measured smaller but
+	// caused visible banding, so it was rejected in favor of the size cut
+	// below, which doesn't touch color depth at all.
+	//
+	// GIF_SCALE_FACTOR downscales the *composited* frame (not the canvas
+	// render itself, which stays at the full chosen resolution) right before
+	// the palette/gif encode stage — this trims pixel count (the dominant
+	// cost driver for GIF size, more so than frame count: mpdecimate-style
+	// duplicate-frame dropping was measured to barely move file size at all)
+	// without reducing color count or introducing dithering artifacts.
+	// Rendering at full resolution and downscaling afterwards also looks
+	// better than natively rendering smaller would (closer to supersampling)
+	// — confirmed by pixel-comparing extracted frames: no visible banding,
+	// unlike the max_colors approach. Measured ~8.9MB at 360p/15fps (down
+	// from ~18.1MB unscaled), comfortably inside a 5-10MB target.
+	const GIF_SCALE_FACTOR = 2 / 3;
 	const filterComplex =
 		format === "gif"
-			? `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp];[comp]split[a][b];[a]palettegen=max_colors=40[pal];[b][pal]paletteuse=dither=bayer:bayer_scale=5[out]`
+			? `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp];[comp]scale=iw*${GIF_SCALE_FACTOR}:ih*${GIF_SCALE_FACTOR}[small];[small]split[a][b];[a]palettegen[pal];[b][pal]paletteuse=dither=bayer:bayer_scale=5[out]`
 			: `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp]`;
 
 	const mapArgs =

--- a/server/export.ts
+++ b/server/export.ts
@@ -37,10 +37,11 @@ export const DEFAULT_FORMAT: ExportFormat = "mp4";
 // video-like content make high resolution/framerate impractically slow and
 // huge: measured at ~146s/~324MB for 1080p/60fps, vs ~20s/~6MB for the same
 // settings as WebM. Clamping GIF down keeps one format from blowing the
-// render-time budget every other export relies on. 360p/24fps was measured
-// at ~16.5s/~39MB — still the biggest file of any capped combination, but
-// comfortably within the render-time budget.
-export const GIF_MAX_RESOLUTION: Resolution = "360p";
+// render-time budget every other export relies on — 720p is excluded, but
+// 360p/480p are both allowed at full (unscaled) resolution: the client
+// warns with a real size estimate before the user commits to one of these,
+// rather than silently capping resolution further the way fps still is.
+export const GIF_MAX_RESOLUTION: Resolution = "480p";
 export const GIF_MAX_FPS: FrameRate = 24;
 
 const RESOLUTION_ORDER: Resolution[] = ["360p", "480p", "720p"];
@@ -309,26 +310,16 @@ export async function renderExport(
 	// difference at bayer_scale=5 (the coarsest/most size-efficient setting)
 	// vs the default. The full 256-color palette (palettegen's default) is
 	// kept as-is — capping max_colors was tried and measured smaller but
-	// caused visible banding, so it was rejected in favor of the size cut
-	// below, which doesn't touch color depth at all.
+	// caused visible banding, so it was rejected.
 	//
-	// GIF_SCALE_FACTOR downscales the *composited* frame (not the canvas
-	// render itself, which stays at the full chosen resolution) right before
-	// the palette/gif encode stage — this trims pixel count (the dominant
-	// cost driver for GIF size, more so than frame count: mpdecimate-style
-	// duplicate-frame dropping was measured to barely move file size at all)
-	// without reducing color count or introducing dithering artifacts.
-	// Rendering at full resolution and downscaling afterwards also looks
-	// better than natively rendering smaller would (closer to supersampling)
-	// — confirmed by pixel-comparing extracted frames: no visible banding at
-	// any factor tested down to 0.45. 0.5 (an even half-resolution downscale,
-	// e.g. 640x360 -> 320x180) was measured at ~8.2MB at 360p/24fps (GIF's
-	// max framerate, the worst case for size) and ~5MB at 360p/15fps —
-	// comfortably inside a 5-8MB target across GIF's whole fps range.
-	const GIF_SCALE_FACTOR = 0.5;
+	// No automatic downscale is applied either (an earlier version silently
+	// halved the composited frame before encoding to keep files small) — the
+	// user asked for real 360p/480p GIF output instead, so full resolution
+	// is used at whatever tier is selected and the client warns with a real
+	// size estimate up front instead of the server quietly shrinking it.
 	const filterComplex =
 		format === "gif"
-			? `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp];[comp]scale=iw*${GIF_SCALE_FACTOR}:ih*${GIF_SCALE_FACTOR}[small];[small]split[a][b];[a]palettegen[pal];[b][pal]paletteuse=dither=bayer:bayer_scale=5[out]`
+			? `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp];[comp]split[a][b];[a]palettegen[pal];[b][pal]paletteuse=dither=bayer:bayer_scale=5[out]`
 			: `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp]`;
 
 	const mapArgs =

--- a/server/server.ts
+++ b/server/server.ts
@@ -3,7 +3,19 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import randomstring from "randomstring";
 import index from "../client/index.html";
-import { type ExportFormat, renderExportInWorker } from "./export";
+import {
+	clampForGif,
+	DEFAULT_FORMAT,
+	DEFAULT_FPS,
+	DEFAULT_RESOLUTION,
+	EXPORT_FORMATS,
+	type ExportFormat,
+	FRAME_RATES,
+	type FrameRate,
+	RESOLUTIONS,
+	type Resolution,
+	renderExportInWorker,
+} from "./export";
 
 // Fixed on purpose: the app always listens on 9595 inside the container (or
 // on the host, if run directly with `bun server/server.ts`). Only the Docker
@@ -129,6 +141,7 @@ let exportProgress = 0;
 const EXPORT_CONTENT_TYPE: Record<ExportFormat, string> = {
 	mp4: "video/mp4",
 	webm: "video/webm",
+	gif: "image/gif",
 };
 
 const server = Bun.serve({
@@ -136,9 +149,16 @@ const server = Bun.serve({
 	// Bun's default is 10s — too short for '/export/*'. No response bytes
 	// are written until the whole render finishes (a single Response at the
 	// end, not streamed), so the entire render duration counts against this
-	// timeout. Renders have been observed to take ~3-5s under normal load;
-	// generous margin here for slower/busier hosts.
-	idleTimeout: 30,
+	// timeout. Resolution/framerate/format are now configurable, capped at
+	// 720p (background.mp4's own native resolution — no point exporting
+	// larger); measured worst case at 1920x1080@60fps (before that tier was
+	// removed) was ~13s as MP4, ~20s as WebM, so 720p is safely under that.
+	// GIF is separately capped to 360p/24fps (see clampForGif in
+	// server/export.ts — uncapped GIF at 1080p/60fps was measured at ~146s,
+	// dangerously close to a timeout and disproportionate to every other
+	// combination) and was measured at ~16.5s at that cap. 60 leaves several
+	// times margin over every real worst case observed.
+	idleTimeout: 60,
 	routes: {
 		"/": index,
 
@@ -233,15 +253,38 @@ const server = Bun.serve({
 				url.searchParams.get("orientation") === "portrait"
 					? "portrait"
 					: "landscape";
-			const format: ExportFormat =
-				url.searchParams.get("format") === "webm" ? "webm" : "mp4";
+
+			const rawFormat = url.searchParams.get("format");
+			const format: ExportFormat = EXPORT_FORMATS.includes(
+				rawFormat as ExportFormat,
+			)
+				? (rawFormat as ExportFormat)
+				: DEFAULT_FORMAT;
+
+			const rawResolution = url.searchParams.get("resolution");
+			let resolution: Resolution = RESOLUTIONS.includes(
+				rawResolution as Resolution,
+			)
+				? (rawResolution as Resolution)
+				: DEFAULT_RESOLUTION;
+
+			const rawFps = Number(url.searchParams.get("fps"));
+			let fps: FrameRate = FRAME_RATES.includes(rawFps as FrameRate)
+				? (rawFps as FrameRate)
+				: DEFAULT_FPS;
+
+			// enforced server-side too, not just via the client's disabled
+			// buttons — a direct request could otherwise bypass the cap
+			if (format === "gif") {
+				({ resolution, fps } = clampForGif(resolution, fps));
+			}
 
 			exportInProgress = true;
 			exportProgress = 0;
 			const dir = await mkdtemp(join(tmpdir(), "shooting-stars-export-"));
 			try {
 				const outputPath = await renderExportInWorker(
-					{ imagePath, orientation, format, dir },
+					{ imagePath, orientation, resolution, fps, format, dir },
 					(percent) => {
 						exportProgress = percent;
 					},
@@ -251,6 +294,8 @@ const server = Bun.serve({
 					"export OK:",
 					hash || "(default)",
 					orientation,
+					resolution,
+					`${fps}fps`,
 					format,
 					`${bytes.byteLength} bytes`,
 				);

--- a/server/server.ts
+++ b/server/server.ts
@@ -153,11 +153,13 @@ const server = Bun.serve({
 	// 720p (background.mp4's own native resolution — no point exporting
 	// larger); measured worst case at 1920x1080@60fps (before that tier was
 	// removed) was ~13s as MP4, ~20s as WebM, so 720p is safely under that.
-	// GIF is separately capped to 360p/24fps (see clampForGif in
+	// GIF is separately capped to 480p/24fps (see clampForGif in
 	// server/export.ts — uncapped GIF at 1080p/60fps was measured at ~146s,
 	// dangerously close to a timeout and disproportionate to every other
-	// combination) and was measured at ~16.5s at that cap. 60 leaves several
-	// times margin over every real worst case observed.
+	// combination) and was measured at ~13s at that cap (480p/24fps, GIF's
+	// own worst case, produces a ~42MB file — slow/big but still nowhere
+	// near this timeout). 60 leaves several times margin over every real
+	// worst case observed.
 	idleTimeout: 60,
 	routes: {
 		"/": index,

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -261,6 +261,58 @@ describe("GET /export/*", () => {
 		expect(res.headers.get("Content-Type")).toBe("video/mp4");
 	}, 30_000);
 
+	test("defaults to 480p/24fps for unrecognized resolution/fps values", async () => {
+		const res = await fetch(
+			new URL(
+				"/export/?resolution=not-a-real-resolution&fps=not-a-real-fps",
+				server.url,
+			),
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toBe("video/mp4");
+	}, 30_000);
+
+	// a smaller-than-default tier (rather than one of the larger/slower ones)
+	// is enough to prove the resolution param is actually threaded through
+	test("renders at a non-default resolution tier", async () => {
+		const res = await fetch(new URL("/export/?resolution=360p", server.url));
+		expect(res.status).toBe(200);
+		const bytes = await res.arrayBuffer();
+		expect(bytes.byteLength).toBeGreaterThan(1000);
+	}, 30_000);
+
+	// GIF needs an extra palettegen/paletteuse filter pass (see
+	// server/export.ts) on top of the same compositing work the video
+	// formats do, so it's the slowest of the three — generous timeout
+	test("renders the default doge animation as a real GIF export", async () => {
+		const res = await fetch(
+			new URL("/export/?orientation=landscape&format=gif", server.url),
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toBe("image/gif");
+		expect(res.headers.get("Content-Disposition")).toBe(
+			'attachment; filename="doge.gif"',
+		);
+		const bytes = await res.arrayBuffer();
+		expect(bytes.byteLength).toBeGreaterThan(1000);
+	}, 60_000);
+
+	// GIF at high resolution/framerate was measured at ~146s/~324MB at the
+	// old (now-removed) 1080p/60fps tier vs ~20s/~6MB as WebM at the same
+	// settings — clampForGif() in server/export.ts silently downgrades a GIF
+	// request above 360p/24fps rather than rendering it as requested, so a
+	// request that asks for 720p/60fps GIF (the current max tier) should
+	// still come back quickly, not hang for over a minute
+	test("clamps GIF resolution/fps down from an oversized request", async () => {
+		const start = Date.now();
+		const res = await fetch(
+			new URL("/export/?resolution=720p&fps=60&format=gif", server.url),
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toBe("image/gif");
+		expect(Date.now() - start).toBeLessThan(60_000);
+	}, 60_000);
+
 	// covers the hash-based naming path (the "doge" case above only covers
 	// the no-hash fallback) — same filename-building code regardless of
 	// format, so one format is enough to guard against a regression back to

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -300,9 +300,10 @@ describe("GET /export/*", () => {
 	// GIF at high resolution/framerate was measured at ~146s/~324MB at the
 	// old (now-removed) 1080p/60fps tier vs ~20s/~6MB as WebM at the same
 	// settings — clampForGif() in server/export.ts silently downgrades a GIF
-	// request above 360p/24fps rather than rendering it as requested, so a
-	// request that asks for 720p/60fps GIF (the current max tier) should
-	// still come back quickly, not hang for over a minute
+	// request above 480p/24fps rather than rendering it as requested (GIF
+	// itself excludes the 720p tier entirely), so a request that asks for
+	// 720p/60fps GIF should still come back quickly, not hang for over a
+	// minute
 	test("clamps GIF resolution/fps down from an oversized request", async () => {
 		const start = Date.now();
 		const res = await fetch(


### PR DESCRIPTION
## Summary
- Replaces the MP4/WebM popover with a dedicated pre-export dialog: orientation, resolution (360p/480p/720p), framerate (15/24/60), and format (MP4/WebM/GIF), all selectable before rendering starts.
- Fixes two real bugs found along the way: the output framerate wasn't actually being forced (so choosing anything other than ~24fps had little to no visible effect), and the GIF pipeline's progress bar froze at a fixed percentage for several seconds during ffmpeg's palette/encode finalization.
- GIF is tuned for quality (full 256-color palette, Bayer dithering instead of the noisier default) rather than shrunk automatically — resolution is capped to 480p (720p excluded, GIF is already the slowest/biggest format at that size) and the dialog shows a live size estimate (e.g. "~42MB") so the trade-off is explicit instead of hidden.
- Default export orientation is now based on device type (mobile → portrait, everything else → landscape) rather than the current viewport orientation.

## Test plan
- [x] `just check` (typecheck + lint + stars.css freshness) passes
- [x] `just test` — full suite (26 tests) passes, including new GIF/resolution/framerate/clamping cases
- [x] Manual browser verification: dialog opens with correct defaults, GIF format correctly disables/relabels resolution+framerate options above its cap and shows the live size warning, a full export→download round trip completes for MP4 and GIF
- [x] Empirically measured real render times/output sizes for every resolution/framerate/format combination against the server's `idleTimeout` budget (worst case ~13s, well within the 60s limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a configurable export pipeline with a pre-export options dialog and full support for MP4, WebM, and GIF outputs, including resolution/framerate controls and GIF-specific safeguards.

New Features:
- Add a pre-export dialog that lets users choose orientation, resolution tier, framerate, and format before starting an export.
- Enable GIF as a first-class export format alongside MP4 and WebM, with client-server support for capped resolution/framerate.
- Expose resolution tiers (360p/480p/720p) and frame rates (15/24/60 fps) as configurable export parameters wired through the client and server.

Bug Fixes:
- Ensure the exported video is actually encoded at the selected framerate instead of inheriting the background video’s native rate.
- Fix GIF export progress reporting so the UI shows ongoing finalization work instead of freezing at a misleading percentage.

Enhancements:
- Refine export defaults and orientation behavior, using device type to choose portrait vs landscape and stable defaults for resolution/fps/format.
- Add server-side validation and clamping of export format/resolution/fps, including GIF caps to keep render time and file size within safe limits.
- Improve export progress handling by capping frame-loop progress below 100% and only reporting true completion once ffmpeg finishes.
- Update styling and layout to use a dedicated export options dialog with an export-options card and GIF size warning messaging.

Tests:
- Extend server export tests to cover resolution/fps parameter handling, defaulting on invalid values, GIF export behavior, and GIF clamping of oversized requests.