### PR TITLE
fix: consistent mobile layout for export options dialog

### DIFF
--- a/client/css/responsive.css
+++ b/client/css/responsive.css
@@ -105,7 +105,6 @@
 		dialog#export-options-dialog,
 		dialog#export-progress-dialog {
 			width: min(94vw, 360px);
-			max-width: 94vw;
 		}
 
 		.export-options-card,
@@ -116,13 +115,13 @@
 			box-sizing: border-box;
 		}
 
-		.option-row {
+		.export-options-card .option-row {
 			flex-direction: column;
 			align-items: stretch;
 			gap: 8px;
 		}
 
-		.tool-picker {
+		.export-options-card .tool-picker {
 			flex-wrap: wrap;
 		}
 	}

--- a/client/css/responsive.css
+++ b/client/css/responsive.css
@@ -95,6 +95,36 @@
 			font-size: 10px;
 			padding: 6px 10px;
 		}
+
+		/* the export options dialog sizes itself to its widest .option-row
+           (format, 3 buttons) — on a narrow viewport the dialog then gets
+           squeezed below that intrinsic width, so which rows wrap becomes a
+           per-row accident of how much text that row happens to hold. Force
+           every row to stack the same way instead, and cap the dialog's own
+           width so content can't push it into a horizontal scrollbar. */
+		dialog#export-options-dialog,
+		dialog#export-progress-dialog {
+			width: min(94vw, 360px);
+			max-width: 94vw;
+		}
+
+		.export-options-card,
+		.export-progress-card {
+			width: 100%;
+			min-width: 0;
+			padding: 20px;
+			box-sizing: border-box;
+		}
+
+		.option-row {
+			flex-direction: column;
+			align-items: stretch;
+			gap: 8px;
+		}
+
+		.tool-picker {
+			flex-wrap: wrap;
+		}
 	}
 
 	/* touch-primary devices can't drag-and-drop or Ctrl-V paste (see


### PR DESCRIPTION
## Summary
- The export options dialog's `.option-row`s (orientation/resolution/framerate/format) sized the dialog to whichever row happened to be widest (format, 3 buttons), so on narrow viewports other rows wrapped inconsistently — label+picker on one line for some rows, wrapped for others — and the dialog could overflow into a horizontal scrollbar.
- Cap the dialog width on mobile and stack each row's label above its button group so every row lays out the same way, with `.tool-picker` wrapping instead of overflowing.

## Test plan
- [x] `just check` passes (typecheck, biome, stars.css freshness)
- [x] Manually verify export options dialog on a mobile viewport (no scrollbar, consistent row layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve mobile layout consistency for export options and progress dialogs by constraining dialog width and standardizing row stacking and button wrapping.

Bug Fixes:
- Prevent horizontal overflow and scrollbars in export options and progress dialogs on narrow mobile viewports.
- Ensure export option rows lay out consistently on mobile by stacking labels above controls and allowing tool pickers to wrap.