### PR TITLE
refactor: ffmpeg filter objects, trim narration comments, extract sub-methods

### DIFF
--- a/client/animation.ts
+++ b/client/animation.ts
@@ -4,9 +4,7 @@
 import { ANIMATION_TIMELINE, pictureAnimationKey } from "./animation-timeline";
 
 const video = document.getElementById("video") as HTMLVideoElement;
-// set video volume to 5%
 video.volume = 0.05;
-// once the video has ended, restart the animation
 video.addEventListener("ended", restartAnimation, false);
 
 /**
@@ -151,18 +149,14 @@ export function startAnimation() {
 }
 
 function scheduleTimeline() {
-	// main loop for class change events
 	for (const time in ANIMATION_TIMELINE) {
 		const stage = ANIMATION_TIMELINE[Number(time)];
 		const id = setTimeout(() => {
-			// foreach pictures
 			for (let i = pictures.length - 1; i >= 0; i--) {
 				const img = document.getElementById(pictures[i]) as HTMLElement;
-				// if the picture is in the current animation array, add the correct class
 				if (stage.pictures.indexOf(pictures[i]) > -1) {
 					img.className = pictureAnimationKey(stage.class, i);
 				} else {
-					// else, hide the picture
 					img.className = "hide";
 				}
 			}

--- a/client/preview.ts
+++ b/client/preview.ts
@@ -24,6 +24,25 @@ const NETWORK_ERROR_MESSAGE = "Couldn't reach the server. Please try again.";
 
 const UPLOAD_ERROR_DISMISS_MS = 6000;
 
+// classifies a completed '/upload' fetch response into either a successful
+// hash or a message to show — kept separate from the dialog-closing/
+// onUploaded side effects that act on it
+function classifyUploadResult(
+	res: Response,
+): { hash: string } | { message: string } {
+	if (res.status >= 500) return { message: SERVER_ERROR_MESSAGE };
+
+	// fetch already followed the 303, so this is the final URL — a bare '/'
+	// means the upload was rejected server-side (see the `error` query
+	// param for why)
+	const url = new URL(res.url);
+	const hash = url.pathname.slice(1);
+	if (hash) return { hash };
+
+	const reason = url.searchParams.get("error") ?? "";
+	return { message: UPLOAD_ERROR_MESSAGES[reason] ?? DEFAULT_UPLOAD_ERROR };
+}
+
 export function initPreviewDialog(onUploaded: (hash: string) => void) {
 	const fileInput = document.getElementById("file-upload") as HTMLInputElement;
 	const previewDialog = document.getElementById(
@@ -285,27 +304,10 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 				method: "POST",
 				body: formData,
 			});
-
-			if (res.status >= 500) {
-				previewDialog.close();
-				showUploadError(SERVER_ERROR_MESSAGE);
-				return;
-			}
-
-			// fetch already followed the 303, so this is the final URL —
-			// a bare '/' means the upload was rejected server-side (see
-			// the `error` query param for why)
-			const url = new URL(res.url);
-			const hash = url.pathname.slice(1);
-			if (hash) {
-				previewDialog.close();
-				onUploaded(hash);
-				return;
-			}
-
+			const result = classifyUploadResult(res);
 			previewDialog.close();
-			const reason = url.searchParams.get("error") ?? "";
-			showUploadError(UPLOAD_ERROR_MESSAGES[reason] ?? DEFAULT_UPLOAD_ERROR);
+			if ("hash" in result) onUploaded(result.hash);
+			else showUploadError(result.message);
 		} catch {
 			previewDialog.close();
 			showUploadError(NETWORK_ERROR_MESSAGE);

--- a/client/script.ts
+++ b/client/script.ts
@@ -12,7 +12,6 @@ function requireElement<T extends Element>(id: string): T {
 	return el as unknown as T;
 }
 
-// pictures
 const picturesContainer = document.getElementById(
 	"pictures-container",
 ) as HTMLElement;
@@ -68,7 +67,6 @@ copyLinkBtn.addEventListener("click", async () => {
 	showCopyToast();
 });
 
-// init animation
 restartAnimation();
 
 initPreviewDialog(applyUploadedImage);

--- a/client/transparency.ts
+++ b/client/transparency.ts
@@ -4,6 +4,46 @@ type Tool = "erase" | "pick";
 
 const MAX_HISTORY = 20;
 
+// draws one erase dab (destination-out) into ctx at (x, y) with the given radius
+function eraseAt(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+	radius: number,
+) {
+	ctx.save();
+	ctx.globalCompositeOperation = "destination-out";
+	ctx.beginPath();
+	ctx.arc(x, y, radius, 0, Math.PI * 2);
+	ctx.fill();
+	ctx.restore();
+}
+
+// makes every pixel within `tolerance` color-distance of (x, y) transparent
+// (simple Euclidean RGB distance, no edge feathering)
+function pickColorAt(
+	ctx: CanvasRenderingContext2D,
+	canvas: HTMLCanvasElement,
+	x: number,
+	y: number,
+	tolerance: number,
+) {
+	const [r, g, b] = ctx.getImageData(x, y, 1, 1).data;
+	const maxDistance = (tolerance / 100) * 441.67; // sqrt(255^2 * 3)
+
+	const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+	const { data } = imageData;
+	for (let i = 0; i < data.length; i += 4) {
+		const dr = data[i] - r;
+		const dg = data[i + 1] - g;
+		const db = data[i + 2] - b;
+		if (Math.sqrt(dr * dr + dg * dg + db * db) <= maxDistance) {
+			data[i + 3] = 0;
+		}
+	}
+	ctx.putImageData(imageData, 0, 0);
+}
+
 export function initTransparencyTools(canvas: HTMLCanvasElement) {
 	const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
 
@@ -127,35 +167,6 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		};
 	}
 
-	function eraseAt(x: number, y: number) {
-		const radius = Number(eraseSizeInput.value);
-		ctx.save();
-		ctx.globalCompositeOperation = "destination-out";
-		ctx.beginPath();
-		ctx.arc(x, y, radius, 0, Math.PI * 2);
-		ctx.fill();
-		ctx.restore();
-	}
-
-	// makes every pixel within `tolerance` color-distance of the clicked pixel
-	// transparent (simple Euclidean RGB distance, no edge feathering)
-	function pickColorAt(x: number, y: number) {
-		const [r, g, b] = ctx.getImageData(x, y, 1, 1).data;
-		const maxDistance = (Number(pickToleranceInput.value) / 100) * 441.67; // sqrt(255^2 * 3)
-
-		const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-		const { data } = imageData;
-		for (let i = 0; i < data.length; i += 4) {
-			const dr = data[i] - r;
-			const dg = data[i + 1] - g;
-			const db = data[i + 2] - b;
-			if (Math.sqrt(dr * dr + dg * dg + db * db) <= maxDistance) {
-				data[i + 3] = 0;
-			}
-		}
-		ctx.putImageData(imageData, 0, 0);
-	}
-
 	canvas.onpointerdown = (e: PointerEvent) => {
 		// computed once for the whole stroke, not per move — see canvasPoint
 		const rect = contentRect();
@@ -163,11 +174,17 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		pushHistory();
 
 		if (tool === "pick") {
-			pickColorAt(point.x, point.y);
+			pickColorAt(
+				ctx,
+				canvas,
+				point.x,
+				point.y,
+				Number(pickToleranceInput.value),
+			);
 			return;
 		}
 
-		eraseAt(point.x, point.y);
+		eraseAt(ctx, point.x, point.y, Number(eraseSizeInput.value));
 		canvas.setPointerCapture(e.pointerId);
 
 		// touch pointermove can fire faster than the display refreshes;
@@ -180,7 +197,14 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 			rafScheduled = true;
 			requestAnimationFrame(() => {
 				rafScheduled = false;
-				if (pendingPoint) eraseAt(pendingPoint.x, pendingPoint.y);
+				if (pendingPoint) {
+					eraseAt(
+						ctx,
+						pendingPoint.x,
+						pendingPoint.y,
+						Number(eraseSizeInput.value),
+					);
+				}
 			});
 		};
 		// 'lostpointercapture' — rather than 'pointerup' alone — is what

--- a/client/transparency.ts
+++ b/client/transparency.ts
@@ -30,6 +30,7 @@ function pickColorAt(
 ) {
 	const [r, g, b] = ctx.getImageData(x, y, 1, 1).data;
 	const maxDistance = (tolerance / 100) * 441.67; // sqrt(255^2 * 3)
+	const maxDistanceSquared = maxDistance * maxDistance;
 
 	const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
 	const { data } = imageData;
@@ -37,7 +38,7 @@ function pickColorAt(
 		const dr = data[i] - r;
 		const dg = data[i + 1] - g;
 		const db = data[i + 2] - b;
-		if (Math.sqrt(dr * dr + dg * dg + db * db) <= maxDistance) {
+		if (dr * dr + dg * dg + db * db <= maxDistanceSquared) {
 			data[i + 3] = 0;
 		}
 	}

--- a/server/export.ts
+++ b/server/export.ts
@@ -137,9 +137,7 @@ async function renderFrames(
 	const canvas = createCanvas(viewport.width, viewport.height);
 	const ctx = canvas.getContext("2d");
 
-	const totalFrames = Math.ceil((EXPORT_DURATION_MS / 1000) * fps);
-	for (let n = 0; n < totalFrames; n++) {
-		const frameTimeMs = (n * 1000) / fps;
+	function drawFrame(frameTimeMs: number) {
 		const stage = findStage(frameTimeMs);
 		const elapsed = frameTimeMs - stage.startMs;
 
@@ -187,6 +185,12 @@ async function renderFrames(
 			);
 			ctx.restore();
 		}
+	}
+
+	const totalFrames = Math.ceil((EXPORT_DURATION_MS / 1000) * fps);
+	for (let n = 0; n < totalFrames; n++) {
+		const frameTimeMs = (n * 1000) / fps;
+		drawFrame(frameTimeMs);
 
 		await onFrame(canvas.data());
 		// frames are piped into ffmpeg as they're generated (not rendered
@@ -247,18 +251,41 @@ const ENCODE_ARGS: Record<"mp4" | "webm", string[]> = {
 	],
 };
 
-export async function renderExport(
-	imagePath: string,
-	orientation: Orientation,
-	resolution: Resolution,
+type FfmpegFilterStep = {
+	filter: string;
+	args?: Record<string, string | number>;
+};
+
+type FfmpegFilterChain = {
+	inputs?: string[];
+	steps: FfmpegFilterStep[];
+	outputs?: string[];
+};
+
+function renderFilterChain(chain: FfmpegFilterChain): string {
+	const inputs = (chain.inputs ?? []).map((label) => `[${label}]`).join("");
+	const outputs = (chain.outputs ?? []).map((label) => `[${label}]`).join("");
+	const steps = chain.steps
+		.map(({ filter, args }) => {
+			if (!args || Object.keys(args).length === 0) return filter;
+			const params = Object.entries(args)
+				.map(([key, value]) => `${key}=${value}`)
+				.join(":");
+			return `${filter}=${params}`;
+		})
+		.join(",");
+	return `${inputs}${steps}${outputs}`;
+}
+
+function renderFilterComplex(chains: FfmpegFilterChain[]): string {
+	return chains.map(renderFilterChain).join(";");
+}
+
+function buildFilterComplex(
+	viewport: { width: number; height: number },
 	fps: FrameRate,
 	format: ExportFormat,
-	dir: string,
-	onProgress?: (percent: number) => void,
-): Promise<string> {
-	const viewport = VIEWPORTS[orientation][resolution];
-	const outPath = join(dir, `export.${format}`);
-
+): string {
 	// cover-crops the source background.mp4 (1280x720) down/up to the
 	// export's viewport — for portrait this also reshapes the aspect ratio,
 	// matching the CSS `min-width/min-height: 100%` "cover" sizing the
@@ -273,7 +300,29 @@ export async function renderExport(
 	// repeated 331 times, at 60fps before this fix) — the picture motion
 	// itself needs the *main* input resampled to the target rate so overlay
 	// actually consumes a distinct overlay frame every output frame.
-	const bgFilter = `scale=${viewport.width}:${viewport.height}:force_original_aspect_ratio=increase,crop=${viewport.width}:${viewport.height},fps=${fps}`;
+	const bg: FfmpegFilterChain = {
+		inputs: ["0:v"],
+		steps: [
+			{
+				filter: "scale",
+				args: {
+					w: viewport.width,
+					h: viewport.height,
+					force_original_aspect_ratio: "increase",
+				},
+			},
+			{ filter: "crop", args: { w: viewport.width, h: viewport.height } },
+			{ filter: "fps", args: { fps } },
+		],
+		outputs: ["bg"],
+	};
+	const overlay: FfmpegFilterChain = {
+		inputs: ["bg", "1:v"],
+		steps: [{ filter: "overlay", args: { shortest: 1 } }],
+		outputs: ["comp"],
+	};
+
+	if (format !== "gif") return renderFilterComplex([bg, overlay]);
 
 	// GIF has no audio track and needs a palette pass for reasonable
 	// quality (ffmpeg's default GIF encoder without one looks banded/dithered
@@ -293,10 +342,34 @@ export async function renderExport(
 	// user asked for real 360p/480p GIF output instead, so full resolution
 	// is used at whatever tier is selected and the client warns with a real
 	// size estimate up front instead of the server quietly shrinking it.
-	const filterComplex =
-		format === "gif"
-			? `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp];[comp]split[a][b];[a]palettegen[pal];[b][pal]paletteuse=dither=bayer:bayer_scale=5[out]`
-			: `[0:v]${bgFilter}[bg];[bg][1:v]overlay=shortest=1[comp]`;
+	return renderFilterComplex([
+		bg,
+		overlay,
+		{ inputs: ["comp"], steps: [{ filter: "split" }], outputs: ["a", "b"] },
+		{ inputs: ["a"], steps: [{ filter: "palettegen" }], outputs: ["pal"] },
+		{
+			inputs: ["b", "pal"],
+			steps: [
+				{ filter: "paletteuse", args: { dither: "bayer", bayer_scale: 5 } },
+			],
+			outputs: ["out"],
+		},
+	]);
+}
+
+export async function renderExport(
+	imagePath: string,
+	orientation: Orientation,
+	resolution: Resolution,
+	fps: FrameRate,
+	format: ExportFormat,
+	dir: string,
+	onProgress?: (percent: number) => void,
+): Promise<string> {
+	const viewport = VIEWPORTS[orientation][resolution];
+	const outPath = join(dir, `export.${format}`);
+
+	const filterComplex = buildFilterComplex(viewport, fps, format);
 
 	const mapArgs =
 		format === "gif" ? ["-map", "[out]"] : ["-map", "[comp]", "-map", "0:a?"];

--- a/server/server.ts
+++ b/server/server.ts
@@ -12,6 +12,7 @@ import {
 	type ExportFormat,
 	FRAME_RATES,
 	type FrameRate,
+	type Orientation,
 	RESOLUTIONS,
 	type Resolution,
 	renderExportInWorker,
@@ -144,6 +145,54 @@ const EXPORT_CONTENT_TYPE: Record<ExportFormat, string> = {
 	gif: "image/gif",
 };
 
+// generates a random upload hash, retrying on an on-disk name collision —
+// collision odds are ~1e-8 at default HASH_LENGTH (see MAX_HASH_ATTEMPTS
+// above), so a fixed small retry cap is enough
+async function generateUploadHash(): Promise<string> {
+	let hash = randomstring.generate(HASH_LENGTH);
+	for (let attempts = 0; attempts < MAX_HASH_ATTEMPTS; attempts++) {
+		const collides = await Bun.file(`${uploadsDir}/${hash}.png`).exists();
+		if (!collides) break;
+		hash = randomstring.generate(HASH_LENGTH);
+	}
+	return hash;
+}
+
+function parseExportOptions(searchParams: URLSearchParams): {
+	orientation: Orientation;
+	format: ExportFormat;
+	resolution: Resolution;
+	fps: FrameRate;
+} {
+	const orientation =
+		searchParams.get("orientation") === "portrait" ? "portrait" : "landscape";
+
+	const rawFormat = searchParams.get("format");
+	const format: ExportFormat = EXPORT_FORMATS.includes(
+		rawFormat as ExportFormat,
+	)
+		? (rawFormat as ExportFormat)
+		: DEFAULT_FORMAT;
+
+	const rawResolution = searchParams.get("resolution");
+	let resolution: Resolution = RESOLUTIONS.includes(rawResolution as Resolution)
+		? (rawResolution as Resolution)
+		: DEFAULT_RESOLUTION;
+
+	const rawFps = Number(searchParams.get("fps"));
+	let fps: FrameRate = FRAME_RATES.includes(rawFps as FrameRate)
+		? (rawFps as FrameRate)
+		: DEFAULT_FPS;
+
+	// enforced server-side too, not just via the client's disabled buttons —
+	// a direct request could otherwise bypass the cap
+	if (format === "gif") {
+		({ resolution, fps } = clampForGif(resolution, fps));
+	}
+
+	return { orientation, format, resolution, fps };
+}
+
 const server = Bun.serve({
 	port: HTTP_PORT,
 	// Bun's default is 10s — too short for '/export/*'. No response bytes
@@ -192,16 +241,8 @@ const server = Bun.serve({
 					);
 				}
 
-				let hash = randomstring.generate(HASH_LENGTH);
-				let storedName = `${hash}.png`;
-				for (let attempts = 0; attempts < MAX_HASH_ATTEMPTS; attempts++) {
-					const collides = await Bun.file(
-						`${uploadsDir}/${storedName}`,
-					).exists();
-					if (!collides) break;
-					hash = randomstring.generate(HASH_LENGTH);
-					storedName = `${hash}.png`;
-				}
+				const hash = await generateUploadHash();
+				const storedName = `${hash}.png`;
 				await Bun.write(`${uploadsDir}/${storedName}`, file);
 				log("upload OK:", storedName, file.type, `${file.size} bytes`);
 				return withSecurityHeaders(Response.redirect(`/${hash}`, 303));
@@ -251,35 +292,9 @@ const server = Bun.serve({
 				);
 			}
 
-			const orientation =
-				url.searchParams.get("orientation") === "portrait"
-					? "portrait"
-					: "landscape";
-
-			const rawFormat = url.searchParams.get("format");
-			const format: ExportFormat = EXPORT_FORMATS.includes(
-				rawFormat as ExportFormat,
-			)
-				? (rawFormat as ExportFormat)
-				: DEFAULT_FORMAT;
-
-			const rawResolution = url.searchParams.get("resolution");
-			let resolution: Resolution = RESOLUTIONS.includes(
-				rawResolution as Resolution,
-			)
-				? (rawResolution as Resolution)
-				: DEFAULT_RESOLUTION;
-
-			const rawFps = Number(url.searchParams.get("fps"));
-			let fps: FrameRate = FRAME_RATES.includes(rawFps as FrameRate)
-				? (rawFps as FrameRate)
-				: DEFAULT_FPS;
-
-			// enforced server-side too, not just via the client's disabled
-			// buttons — a direct request could otherwise bypass the cap
-			if (format === "gif") {
-				({ resolution, fps } = clampForGif(resolution, fps));
-			}
+			const { orientation, format, resolution, fps } = parseExportOptions(
+				url.searchParams,
+			);
 
 			exportInProgress = true;
 			exportProgress = 0;


### PR DESCRIPTION
## Summary
- `server/export.ts`: represent the ffmpeg `-filter_complex` graph (background scale/crop/fps, overlay, GIF palette chain) as native TS objects (`FfmpegFilterChain`/`FfmpegFilterStep`) rendered to ffmpeg's string syntax by `renderFilterChain`/`renderFilterComplex`, instead of hand-built template-literal strings. Behavior-preserving — verified via `framemd5` byte-identical output and confirmed again by the real MP4/WebM/GIF export tests below.
- Extracted sub-methods to make several oversized functions easier to scan: `drawFrame` out of `renderFrames` (export.ts), `generateUploadHash`/`parseExportOptions` out of the `/upload` and `/export/*` route handlers (server.ts), `classifyUploadResult` out of the upload submit handler (preview.ts), and `eraseAt`/`pickColorAt` promoted to module-scope helpers (transparency.ts).
- Deleted 8 inline comments that only restated the line directly below them (client/animation.ts, client/script.ts). All other comments were reviewed and kept — they explain real gotchas/measured bug workarounds.

## Test plan
- [x] `just check` (tsc --noEmit + biome + stars.css freshness) passes
- [x] `just test` — all 26 tests pass, including real MP4/WebM/GIF export renders exercising the new filter-graph representation end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor export, server, and client logic to improve maintainability while preserving existing export and upload behavior.

Enhancements:
- Represent ffmpeg filter_complex graphs as structured TypeScript objects with helpers to render them into ffmpeg syntax.
- Extract helper functions for frame drawing, upload hash generation, export option parsing, transparency tools, and upload result classification to simplify larger routines.
- Remove redundant narration-style comments from animation and script client code to keep comments focused on non-obvious behavior.