### PR TITLE
refactor: drop randomstring dep, remove dead exports, dedupe interpolate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,12 +7,10 @@
       "dependencies": {
         "@napi-rs/canvas": "^1.0.2",
         "cropperjs": "^2.1.1",
-        "randomstring": "^1.3.1",
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.5",
         "@types/bun": "^1.3.14",
-        "@types/randomstring": "^1.3.0",
         "typescript": "^7.0.2",
       },
     },
@@ -86,8 +84,6 @@
 
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
-    "@types/randomstring": ["@types/randomstring@1.3.0", "", {}, "sha512-kCP61wludjY7oNUeFiMxfswHB3Wn/aC03Cu82oQsNTO6OCuhVN/rCbBs68Cq6Nkgjmp2Sh3Js6HearJPkk7KQA=="],
-
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
     "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
@@ -131,12 +127,6 @@
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cropperjs": ["cropperjs@2.1.1", "", { "dependencies": { "@cropper/elements": "^2.1.1", "@cropper/utils": "^2.1.1" } }, "sha512-FDJMarkY+/SepYarPZsvkG2LmI2PElecciMFnvBiBIoKnFYua/scprC5qejCLLyuX2jEqJRS2njbAsHxfjtIXA=="],
-
-    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
-
-    "randomstring": ["randomstring@1.3.1", "", { "dependencies": { "randombytes": "2.1.0" }, "bin": { "randomstring": "bin/randomstring" } }, "sha512-lgXZa80MUkjWdE7g2+PZ1xDLzc7/RokXVEQOv5NN2UOTChW1I8A9gha5a9xYBOqgaSoI6uJikDmCU8PyRdArRQ=="],
-
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 

--- a/package.json
+++ b/package.json
@@ -24,13 +24,11 @@
 	"license": "MIT",
 	"dependencies": {
 		"@napi-rs/canvas": "^1.0.2",
-		"cropperjs": "^2.1.1",
-		"randomstring": "^1.3.1"
+		"cropperjs": "^2.1.1"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.5",
 		"@types/bun": "^1.3.14",
-		"@types/randomstring": "^1.3.0",
 		"typescript": "^7.0.2"
 	}
 }

--- a/scripts/generate-stars-css.ts
+++ b/scripts/generate-stars-css.ts
@@ -16,7 +16,11 @@
 // `scale(n)` or `scaleX(n)` — computationally identical, no need to
 // reconstruct which literal shorthand was originally used.
 
-import { ANIMATIONS, type PictureAnimation } from "../server/keyframes";
+import {
+	ANIMATIONS,
+	interpolate,
+	type PictureAnimation,
+} from "../server/keyframes";
 
 // className is identical to the ANIMATIONS key for every entry; only the
 // @keyframes animation-name itself differs from the class name for some.
@@ -38,27 +42,6 @@ function realStops(points: { percent: number; implicit?: true }[]): number[] {
 	return points.filter((p) => !p.implicit).map((p) => p.percent);
 }
 
-function interpolateNumber(
-	points: { percent: number; value: number }[],
-	percent: number,
-	identity: number,
-): number {
-	if (points.length === 0) return identity;
-	if (points.length === 1) return points[0].value;
-	if (percent <= points[0].percent) return points[0].value;
-	const last = points[points.length - 1];
-	if (percent >= last.percent) return last.value;
-	for (let i = 0; i < points.length - 1; i++) {
-		const a = points[i];
-		const b = points[i + 1];
-		if (percent >= a.percent && percent <= b.percent) {
-			const localT = (percent - a.percent) / (b.percent - a.percent);
-			return a.value + (b.value - a.value) * localT;
-		}
-	}
-	return identity;
-}
-
 function filterText(anim: PictureAnimation, percent: number): string {
 	const point = anim.filter.find((p) => p.percent === percent && !p.implicit);
 	if (!point) throw new Error(`no explicit filter point at ${percent}%`);
@@ -68,8 +51,8 @@ function filterText(anim: PictureAnimation, percent: number): string {
 }
 
 function transformText(anim: PictureAnimation, percent: number): string {
-	const x = interpolateNumber(anim.x, percent, 0);
-	const y = interpolateNumber(anim.y, percent, 0);
+	const x = interpolate(anim.x, percent, 0);
+	const y = interpolate(anim.y, percent, 0);
 	const translate = `translate(${x}px, ${y}px)`;
 
 	const hasScale =
@@ -77,10 +60,10 @@ function transformText(anim: PictureAnimation, percent: number): string {
 		anim.scaleY.some((p) => !p.implicit);
 	const hasRotate = anim.rotateDeg.some((p) => !p.implicit);
 	const rotate = hasRotate
-		? `rotate(${interpolateNumber(anim.rotateDeg, percent, 0)}deg)`
+		? `rotate(${interpolate(anim.rotateDeg, percent, 0)}deg)`
 		: undefined;
 	const scale = hasScale
-		? `scale(${interpolateNumber(anim.scaleX, percent, 1)}, ${interpolateNumber(anim.scaleY, percent, 1)})`
+		? `scale(${interpolate(anim.scaleX, percent, 1)}, ${interpolate(anim.scaleY, percent, 1)})`
 		: undefined;
 
 	const functions =

--- a/server/export.ts
+++ b/server/export.ts
@@ -30,12 +30,10 @@ import { ANIMATIONS, resolvePictureFrame } from "./keyframes";
 
 export * from "../client/export-options";
 
-export const ORIENTATIONS: Orientation[] = ["landscape", "portrait"];
 export const RESOLUTIONS: Resolution[] = ["360p", "480p", "720p"];
 export const FRAME_RATES: FrameRate[] = [15, 24, 60];
 export const EXPORT_FORMATS: ExportFormat[] = ["mp4", "webm", "gif"];
 
-export const DEFAULT_ORIENTATION: Orientation = "landscape";
 export const DEFAULT_RESOLUTION: Resolution = "480p";
 export const DEFAULT_FPS: FrameRate = 24;
 export const DEFAULT_FORMAT: ExportFormat = "mp4";

--- a/server/keyframes.ts
+++ b/server/keyframes.ts
@@ -747,7 +747,7 @@ export const ANIMATIONS: Record<string, PictureAnimation> = {
 	},
 };
 
-function interpolate(
+export function interpolate(
 	points: ControlPoint[],
 	percent: number,
 	identity: number,

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,7 +1,7 @@
+import { randomInt } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import randomstring from "randomstring";
 import index from "../client/index.html";
 import {
 	clampForGif,
@@ -145,15 +145,26 @@ const EXPORT_CONTENT_TYPE: Record<ExportFormat, string> = {
 	gif: "image/gif",
 };
 
+const HASH_CHARS =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+function randomHash(length: number): string {
+	let hash = "";
+	for (let i = 0; i < length; i++) {
+		hash += HASH_CHARS[randomInt(HASH_CHARS.length)];
+	}
+	return hash;
+}
+
 // generates a random upload hash, retrying on an on-disk name collision —
 // collision odds are ~1e-8 at default HASH_LENGTH (see MAX_HASH_ATTEMPTS
 // above), so a fixed small retry cap is enough
 async function generateUploadHash(): Promise<string> {
-	let hash = randomstring.generate(HASH_LENGTH);
+	let hash = randomHash(HASH_LENGTH);
 	for (let attempts = 0; attempts < MAX_HASH_ATTEMPTS; attempts++) {
 		const collides = await Bun.file(`${uploadsDir}/${hash}.png`).exists();
 		if (!collides) break;
-		hash = randomstring.generate(HASH_LENGTH);
+		hash = randomHash(HASH_LENGTH);
 	}
 	return hash;
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -160,11 +160,11 @@ function randomHash(length: number): string {
 // collision odds are ~1e-8 at default HASH_LENGTH (see MAX_HASH_ATTEMPTS
 // above), so a fixed small retry cap is enough
 async function generateUploadHash(): Promise<string> {
-	let hash = randomHash(HASH_LENGTH);
+	let hash = "";
 	for (let attempts = 0; attempts < MAX_HASH_ATTEMPTS; attempts++) {
+		hash = randomHash(HASH_LENGTH);
 		const collides = await Bun.file(`${uploadsDir}/${hash}.png`).exists();
 		if (!collides) break;
-		hash = randomHash(HASH_LENGTH);
 	}
 	return hash;
 }


### PR DESCRIPTION
- replace randomstring with a small node:crypto-based hash generator, removing the runtime and @types dependency entirely
- delete server/export.ts's ORIENTATIONS/DEFAULT_ORIENTATION exports, unused anywhere in the codebase
- export keyframes.ts's interpolate() instead of maintaining a byte-for-byte copy (interpolateNumber) in generate-stars-css.ts

## Summary by Sourcery

Replace the randomstring-based upload hash generation with a lightweight node:crypto implementation and reuse the shared interpolation helper for animation keyframes while cleaning up unused export constants.

Enhancements:
- Remove the randomstring runtime and type dependencies in favor of a small local hash generator.
- Export the shared interpolate helper from keyframes and consume it in the CSS generation script instead of maintaining a duplicate implementation.
- Drop unused orientation-related exports from the server export module.

Build:
- Update package.json to remove randomstring and its type dependency.