### PR TITLE
fix: reset cancel button state when reopening upload dialog

### DIFF
--- a/client/preview.ts
+++ b/client/preview.ts
@@ -163,6 +163,9 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 
 	function openSourceStep() {
 		setStep("source");
+		// a previous upload in this same dialog session may have left this
+		// disabled — reset it so a fresh upload isn't stuck uncancelable
+		cancelBtn.disabled = false;
 		previewDialog.showModal();
 	}
 


### PR DESCRIPTION
Cancel stayed disabled on a second upload attempt because only showCropStep() reset it, not openSourceStep() (step 1) — Escape still worked since it bypasses the button entirely.

## Summary by Sourcery

Bug Fixes:
- Ensure the cancel button is re-enabled when returning to the upload source step after a previous upload attempt in the same dialog session.