### PR TITLE
test: cover keyframe interpolation, export filter-graph helpers, and export lock

### DIFF
--- a/server/export.ts
+++ b/server/export.ts
@@ -62,14 +62,14 @@ const VIEWPORTS: Record<
 // matches base.css's `--travel-scale: clamp(0.25, calc(100vw / 1400px), 1)`
 // — computed once per orientation since the export always uses a fixed
 // viewport size (no responsive resize mid-render)
-export function travelScale(viewportWidth: number): number {
+function travelScale(viewportWidth: number): number {
 	return Math.min(1, Math.max(0.25, viewportWidth / 1400));
 }
 
 // matches base.css's `img { max-width: calc(30% / var(--travel-scale)) }`
 // (and max-height, same formula against viewport height) — the box an
 // uploaded image is fit into before the keyframe transform applies
-export function pictureBox(
+function pictureBox(
 	viewport: { width: number; height: number },
 	scale: number,
 ) {
@@ -94,7 +94,7 @@ const timeline = Object.entries(ANIMATION_TIMELINE)
 	.map(([ms, stage]) => ({ startMs: Number(ms), ...stage }))
 	.sort((a, b) => a.startMs - b.startMs);
 
-export function findStage(timeMs: number) {
+function findStage(timeMs: number) {
 	let active = timeline[0];
 	for (const stage of timeline) {
 		if (stage.startMs > timeMs) break;
@@ -103,7 +103,7 @@ export function findStage(timeMs: number) {
 	return active;
 }
 
-export function cssFilterString(filter: {
+function cssFilterString(filter: {
 	kind: "none" | "saturate" | "contrast";
 	amount: number;
 }) {
@@ -249,18 +249,18 @@ const ENCODE_ARGS: Record<"mp4" | "webm", string[]> = {
 	],
 };
 
-export type FfmpegFilterStep = {
+type FfmpegFilterStep = {
 	filter: string;
 	args?: Record<string, string | number>;
 };
 
-export type FfmpegFilterChain = {
+type FfmpegFilterChain = {
 	inputs?: string[];
 	steps: FfmpegFilterStep[];
 	outputs?: string[];
 };
 
-export function renderFilterChain(chain: FfmpegFilterChain): string {
+function renderFilterChain(chain: FfmpegFilterChain): string {
 	const inputs = (chain.inputs ?? []).map((label) => `[${label}]`).join("");
 	const outputs = (chain.outputs ?? []).map((label) => `[${label}]`).join("");
 	const steps = chain.steps
@@ -275,11 +275,11 @@ export function renderFilterChain(chain: FfmpegFilterChain): string {
 	return `${inputs}${steps}${outputs}`;
 }
 
-export function renderFilterComplex(chains: FfmpegFilterChain[]): string {
+function renderFilterComplex(chains: FfmpegFilterChain[]): string {
 	return chains.map(renderFilterChain).join(";");
 }
 
-export function buildFilterComplex(
+function buildFilterComplex(
 	viewport: { width: number; height: number },
 	fps: FrameRate,
 	format: ExportFormat,
@@ -478,3 +478,19 @@ export function renderExportInWorker(
 		worker.on("error", reject);
 	});
 }
+
+// grouped under one name, rather than individually exported, so the
+// module's real public API (renderExport/renderExportInWorker/the format
+// constants above) stays the only thing other files can see — these are
+// pure helpers with no I/O, exposed here purely so tests/keyframes.test.ts
+// can call them directly instead of only exercising them incidentally
+// through a full end-to-end render.
+export const testInternals = {
+	travelScale,
+	pictureBox,
+	findStage,
+	cssFilterString,
+	renderFilterChain,
+	renderFilterComplex,
+	buildFilterComplex,
+};

--- a/server/export.ts
+++ b/server/export.ts
@@ -62,14 +62,14 @@ const VIEWPORTS: Record<
 // matches base.css's `--travel-scale: clamp(0.25, calc(100vw / 1400px), 1)`
 // — computed once per orientation since the export always uses a fixed
 // viewport size (no responsive resize mid-render)
-function travelScale(viewportWidth: number): number {
+export function travelScale(viewportWidth: number): number {
 	return Math.min(1, Math.max(0.25, viewportWidth / 1400));
 }
 
 // matches base.css's `img { max-width: calc(30% / var(--travel-scale)) }`
 // (and max-height, same formula against viewport height) — the box an
 // uploaded image is fit into before the keyframe transform applies
-function pictureBox(
+export function pictureBox(
 	viewport: { width: number; height: number },
 	scale: number,
 ) {
@@ -94,7 +94,7 @@ const timeline = Object.entries(ANIMATION_TIMELINE)
 	.map(([ms, stage]) => ({ startMs: Number(ms), ...stage }))
 	.sort((a, b) => a.startMs - b.startMs);
 
-function findStage(timeMs: number) {
+export function findStage(timeMs: number) {
 	let active = timeline[0];
 	for (const stage of timeline) {
 		if (stage.startMs > timeMs) break;
@@ -103,7 +103,7 @@ function findStage(timeMs: number) {
 	return active;
 }
 
-function cssFilterString(filter: {
+export function cssFilterString(filter: {
 	kind: "none" | "saturate" | "contrast";
 	amount: number;
 }) {
@@ -249,18 +249,18 @@ const ENCODE_ARGS: Record<"mp4" | "webm", string[]> = {
 	],
 };
 
-type FfmpegFilterStep = {
+export type FfmpegFilterStep = {
 	filter: string;
 	args?: Record<string, string | number>;
 };
 
-type FfmpegFilterChain = {
+export type FfmpegFilterChain = {
 	inputs?: string[];
 	steps: FfmpegFilterStep[];
 	outputs?: string[];
 };
 
-function renderFilterChain(chain: FfmpegFilterChain): string {
+export function renderFilterChain(chain: FfmpegFilterChain): string {
 	const inputs = (chain.inputs ?? []).map((label) => `[${label}]`).join("");
 	const outputs = (chain.outputs ?? []).map((label) => `[${label}]`).join("");
 	const steps = chain.steps
@@ -275,11 +275,11 @@ function renderFilterChain(chain: FfmpegFilterChain): string {
 	return `${inputs}${steps}${outputs}`;
 }
 
-function renderFilterComplex(chains: FfmpegFilterChain[]): string {
+export function renderFilterComplex(chains: FfmpegFilterChain[]): string {
 	return chains.map(renderFilterChain).join(";");
 }
 
-function buildFilterComplex(
+export function buildFilterComplex(
 	viewport: { width: number; height: number },
 	fps: FrameRate,
 	format: ExportFormat,

--- a/tests/keyframes.test.ts
+++ b/tests/keyframes.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { ANIMATION_TIMELINE } from "../client/animation-timeline.ts";
+import {
+	buildFilterComplex,
+	cssFilterString,
+	findStage,
+	pictureBox,
+	renderFilterChain,
+	renderFilterComplex,
+	travelScale,
+} from "../server/export.ts";
+import {
+	interpolate,
+	type PictureAnimation,
+	resolvePictureFrame,
+} from "../server/keyframes.ts";
+
+describe("interpolate", () => {
+	test("returns the identity value for an empty control-point array", () => {
+		expect(interpolate([], 50, 42)).toBe(42);
+	});
+
+	test("returns the single point's value regardless of percent", () => {
+		const points = [{ percent: 30, value: 7 }];
+		expect(interpolate(points, 0, 0)).toBe(7);
+		expect(interpolate(points, 100, 0)).toBe(7);
+	});
+
+	test("clamps to the first point before it, and the last point after it", () => {
+		const points = [
+			{ percent: 20, value: 10 },
+			{ percent: 80, value: 90 },
+		];
+		expect(interpolate(points, 0, 0)).toBe(10);
+		expect(interpolate(points, 100, 0)).toBe(90);
+	});
+
+	test("linearly interpolates between the surrounding two points", () => {
+		const points = [
+			{ percent: 0, value: 0 },
+			{ percent: 100, value: 200 },
+		];
+		expect(interpolate(points, 25, 0)).toBe(50);
+	});
+});
+
+describe("resolvePictureFrame", () => {
+	// mirrors spacetwo_3's shape: transform/filter only declared from 50%,
+	// with an implicit identity point at 0% for the interpolator to start from
+	const anim: PictureAnimation = {
+		durationMs: 1000,
+		transformOrder: "rotate-scale",
+		x: [
+			{ percent: 0, value: 0, implicit: true },
+			{ percent: 50, value: 0 },
+			{ percent: 100, value: -100 },
+		],
+		y: [],
+		scaleX: [],
+		scaleY: [],
+		rotateDeg: [
+			{ percent: 0, value: 0, implicit: true },
+			{ percent: 50, value: -90 },
+			{ percent: 100, value: -90 },
+		],
+		opacity: [
+			{ percent: 0, value: 0 },
+			{ percent: 50, value: 1 },
+			{ percent: 100, value: 1 },
+		],
+		filter: [
+			{ percent: 0, kind: "none", amount: 1, implicit: true },
+			{ percent: 50, kind: "contrast", amount: 3 },
+			{ percent: 100, kind: "contrast", amount: 3 },
+		],
+	};
+
+	test("resolves the identity boundary at elapsed=0", () => {
+		const frame = resolvePictureFrame(anim, 0);
+		expect(frame.x).toBe(0);
+		expect(frame.scaleX).toBe(1); // no control points -> identity
+		expect(frame.rotateDeg).toBe(0);
+		expect(frame.opacity).toBe(0);
+		// kind is picked from the first non-"none" point regardless of the
+		// queried percent — only amount is actually interpolated
+		expect(frame.filter).toEqual({ kind: "contrast", amount: 1 });
+	});
+
+	test("resolves mid-segment values between two real control points", () => {
+		const frame = resolvePictureFrame(anim, 750);
+		expect(frame.x).toBe(-50); // halfway between 50%(-0) and 100%(-100)
+		expect(frame.filter.amount).toBe(3);
+	});
+
+	test("wraps elapsed time around durationMs, matching CSS's infinite keyframe loop", () => {
+		const early = resolvePictureFrame(anim, 500);
+		const wrapped = resolvePictureFrame(anim, 1500);
+		expect(wrapped).toEqual(early);
+	});
+});
+
+describe("travelScale", () => {
+	test("clamps to the floor below 1400*0.25 viewport width", () => {
+		expect(travelScale(200)).toBe(0.25);
+	});
+
+	test("clamps to the ceiling above 1400 viewport width", () => {
+		expect(travelScale(2800)).toBe(1);
+	});
+
+	test("scales linearly against 1400 in between", () => {
+		expect(travelScale(700)).toBe(0.5);
+	});
+});
+
+describe("pictureBox", () => {
+	test("fits 30% of the viewport, scaled by travel-scale", () => {
+		expect(pictureBox({ width: 1000, height: 500 }, 0.5)).toEqual({
+			width: 600,
+			height: 300,
+		});
+	});
+});
+
+describe("findStage", () => {
+	test("returns the active stage for an exact boundary timestamp", () => {
+		expect(findStage(3900).class).toBe("spaceone");
+	});
+
+	test("returns the previous stage for a timestamp between boundaries", () => {
+		expect(findStage(3899).class).toBe("init");
+		expect(findStage(7699).class).toBe("spaceone");
+	});
+
+	test("returns the last stage once past every boundary", () => {
+		const lastOffset = Math.max(...Object.keys(ANIMATION_TIMELINE).map(Number));
+		expect(findStage(lastOffset + 100_000).class).toBe(
+			ANIMATION_TIMELINE[lastOffset].class,
+		);
+	});
+});
+
+describe("cssFilterString", () => {
+	test("renders 'none' as a bare passthrough", () => {
+		expect(cssFilterString({ kind: "none", amount: 1 })).toBe("none");
+	});
+
+	test("renders saturate/contrast as a percent function", () => {
+		expect(cssFilterString({ kind: "saturate", amount: 2.5 })).toBe(
+			"saturate(250%)",
+		);
+		expect(cssFilterString({ kind: "contrast", amount: 3 })).toBe(
+			"contrast(300%)",
+		);
+	});
+});
+
+describe("renderFilterChain / renderFilterComplex", () => {
+	test("joins inputs, args-bearing steps, and outputs into an ffmpeg chain string", () => {
+		expect(
+			renderFilterChain({
+				inputs: ["0:v"],
+				steps: [{ filter: "scale", args: { w: 100, h: 50 } }],
+				outputs: ["bg"],
+			}),
+		).toBe("[0:v]scale=w=100:h=50[bg]");
+	});
+
+	test("omits the '=' for a step with no args", () => {
+		expect(renderFilterChain({ steps: [{ filter: "split" }] })).toBe("split");
+	});
+
+	test("joins multiple chains with ';'", () => {
+		expect(
+			renderFilterComplex([
+				{ steps: [{ filter: "a" }] },
+				{ steps: [{ filter: "b" }] },
+			]),
+		).toBe("a;b");
+	});
+});
+
+describe("buildFilterComplex", () => {
+	const viewport = { width: 100, height: 50 };
+
+	test("builds the scale/crop/fps/overlay graph for a video format", () => {
+		expect(buildFilterComplex(viewport, 24, "mp4")).toBe(
+			"[0:v]scale=w=100:h=50:force_original_aspect_ratio=increase,crop=w=100:h=50,fps=fps=24[bg];" +
+				"[bg][1:v]overlay=shortest=1[comp]",
+		);
+	});
+
+	test("appends the palettegen/paletteuse pass for gif", () => {
+		expect(buildFilterComplex(viewport, 24, "gif")).toBe(
+			"[0:v]scale=w=100:h=50:force_original_aspect_ratio=increase,crop=w=100:h=50,fps=fps=24[bg];" +
+				"[bg][1:v]overlay=shortest=1[comp];" +
+				"[comp]split[a][b];" +
+				"[a]palettegen[pal];" +
+				"[b][pal]paletteuse=dither=bayer:bayer_scale=5[out]",
+		);
+	});
+});

--- a/tests/keyframes.test.ts
+++ b/tests/keyframes.test.ts
@@ -1,19 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { ANIMATION_TIMELINE } from "../client/animation-timeline.ts";
-import {
-	buildFilterComplex,
-	cssFilterString,
-	findStage,
-	pictureBox,
-	renderFilterChain,
-	renderFilterComplex,
-	travelScale,
-} from "../server/export.ts";
+import { testInternals } from "../server/export.ts";
 import {
 	interpolate,
 	type PictureAnimation,
 	resolvePictureFrame,
 } from "../server/keyframes.ts";
+
+const {
+	travelScale,
+	pictureBox,
+	findStage,
+	cssFilterString,
+	renderFilterChain,
+	renderFilterComplex,
+	buildFilterComplex,
+} = testInternals;
 
 describe("interpolate", () => {
 	test("returns the identity value for an empty control-point array", () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -329,6 +329,18 @@ describe("GET /export/*", () => {
 			`attachment; filename="${hash}.mp4"`,
 		);
 	}, 30_000);
+
+	// exportInProgress is a real single-slot lock (see server/server.ts), not
+	// mocked — firing two renders at once is enough to hit the 429 branch
+	test("rejects a second concurrent export with 429", async () => {
+		const first = fetch(new URL("/export/?orientation=landscape", server.url));
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		const second = await fetch(
+			new URL("/export/?orientation=portrait", server.url),
+		);
+		expect(second.status).toBe(429);
+		await first;
+	}, 30_000);
 });
 
 describe("GET /export-status", () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -331,10 +331,16 @@ describe("GET /export/*", () => {
 	}, 30_000);
 
 	// exportInProgress is a real single-slot lock (see server/server.ts), not
-	// mocked — firing two renders at once is enough to hit the 429 branch
+	// mocked — firing two renders at once is enough to hit the 429 branch.
+	// Polls /export-status instead of a fixed delay to know the lock is
+	// actually held before firing the second request, so this can't flake
+	// under a slow/fast environment the way a hardcoded sleep could.
 	test("rejects a second concurrent export with 429", async () => {
 		const first = fetch(new URL("/export/?orientation=landscape", server.url));
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		while (true) {
+			const status = await fetch(new URL("/export-status", server.url));
+			if ((await status.json()).inProgress) break;
+		}
 		const second = await fetch(
 			new URL("/export/?orientation=portrait", server.url),
 		);


### PR DESCRIPTION
## Summary
- Line coverage was 81.60%, with the biggest gaps in pure, deterministic logic (control-point interpolation in `server/keyframes.ts`, ffmpeg filter-graph string building in `server/export.ts`) that was only exercised incidentally through full end-to-end `/export/*` renders.
- Exports a handful of previously-private helpers in `server/export.ts` (`travelScale`, `pictureBox`, `findStage`, `cssFilterString`, `renderFilterChain`, `renderFilterComplex`, `buildFilterComplex`) — pure visibility change, no behavior change — so they can be unit-tested directly with controlled inputs.
- Adds `tests/keyframes.test.ts`: direct unit tests for `interpolate`, `resolvePictureFrame`, and the newly-exported `export.ts` helpers.
- Adds one test in `tests/server.test.ts` for the `/export/*` route's single-slot concurrency lock (429 "already in progress" branch).

Line coverage moved from 81.60% to 88.04%. `server/keyframes.ts` is now 99.72% covered and `server/server.ts` 96.12%. `server/export.ts`'s remaining gap is the real ffmpeg/canvas rendering pipeline (`renderFrames`/`runFfmpeg`/`renderExport`), left to the existing e2e `/export/*` tests rather than mocked out — see PR discussion if we want to revisit that tradeoff.

## Test plan
- [x] `just check` (tsc + biome + stars.css freshness) passes
- [x] `just test` — 48 tests pass across 3 files
- [x] `just test-coverage` — confirmed the coverage increase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Increase test coverage for keyframe interpolation, export filter-graph helpers, and the export concurrency lock.

Enhancements:
- Export previously internal filter-graph and layout helpers from the export module for direct unit testing.

Tests:
- Add unit tests for keyframe interpolation, picture frame resolution, and exported filter-graph helpers.
- Add a server test verifying the 429 response when a second concurrent export is requested.