### PR TITLE
fix: verify PNG magic bytes on upload instead of trusting Content-Type

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -169,6 +169,19 @@ async function generateUploadHash(): Promise<string> {
 	return hash;
 }
 
+// the 8-byte PNG magic number (see the PNG spec) — checked against the
+// actual uploaded bytes since the client-declared Content-Type can be
+// spoofed by a raw POST, and the stored file is later fed straight into
+// the export renderer's native image decoder
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+async function hasPngSignature(file: Blob): Promise<boolean> {
+	const header = new Uint8Array(
+		await file.slice(0, PNG_SIGNATURE.length).arrayBuffer(),
+	);
+	return PNG_SIGNATURE.every((byte, i) => header[i] === byte);
+}
+
 function parseExportOptions(searchParams: URLSearchParams): {
 	orientation: Orientation;
 	format: ExportFormat;
@@ -232,7 +245,12 @@ const server = Bun.serve({
 				// PNG-only: the client always crops/re-encodes through canvas
 				// before uploading (needed for the transparency-editing
 				// feature regardless of the original file's format), so
-				// there's no legitimate case where anything else arrives here
+				// there's no legitimate case where anything else arrives here.
+				// `file.type` is just the client-declared Content-Type on the
+				// multipart part, not a fact about the actual bytes, so it's
+				// only a cheap early-out here — the magic-byte check below is
+				// what actually gates what gets written to disk and later fed
+				// to the export renderer's native image decoder.
 				if (!(file instanceof Blob) || file.type !== "image/png") {
 					log(
 						"upload rejected: not a PNG",
@@ -249,6 +267,13 @@ const server = Bun.serve({
 					log("upload rejected: too large", `${file.size} bytes`);
 					return withSecurityHeaders(
 						Response.redirect("/?error=too_large", 303),
+					);
+				}
+
+				if (!(await hasPngSignature(file))) {
+					log("upload rejected: not a PNG (bad signature)");
+					return withSecurityHeaders(
+						Response.redirect("/?error=invalid_type", 303),
 					);
 				}
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4,6 +4,12 @@ import server from "../server/server.ts";
 
 const uploadedHashes: string[] = [];
 
+// the real 8-byte PNG magic number, used to build a Blob that passes the
+// server's content-sniffing check regardless of what bytes follow it
+const PNG_SIGNATURE = new Uint8Array([
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
 // used by tests that need a real hash to export by, rather than the default
 // doge image — uploads the real doge.png bytes (not a "fake-png-bytes"
 // placeholder like the plain upload tests use) since exporting actually
@@ -93,7 +99,7 @@ describe("POST /upload", () => {
 		const form = new FormData();
 		form.set(
 			"file-upload",
-			new Blob(["fake-png-bytes"], { type: "image/png" }),
+			new Blob([PNG_SIGNATURE, "fake-png-bytes"], { type: "image/png" }),
 			"test.png",
 		);
 
@@ -130,6 +136,27 @@ describe("POST /upload", () => {
 			"file-upload",
 			new Blob(["fake-png-bytes"], { type: "image/png" }),
 			"photo.jpg",
+		);
+
+		const res = await fetch(new URL("/upload", server.url), {
+			method: "POST",
+			body: form,
+			redirect: "manual",
+		});
+
+		expect(res.status).toBe(303);
+		expect(res.headers.get("location")).toBe("/?error=invalid_type");
+	});
+
+	test("rejects a spoofed Content-Type whose bytes aren't actually a PNG", async () => {
+		// a raw client can declare `image/png` on the multipart part
+		// regardless of the real bytes — the server must check the actual
+		// file content, not just trust the declared type
+		const form = new FormData();
+		form.set(
+			"file-upload",
+			new Blob(["not-a-real-png"], { type: "image/png" }),
+			"test.png",
 		);
 
 		const res = await fetch(new URL("/upload", server.url), {


### PR DESCRIPTION
## Summary
- `/upload` only checked the client-declared `Content-Type` on the multipart file part, which a raw POST can spoof (e.g. claim `image/png` while sending arbitrary bytes)
- Those bytes are written verbatim to `uploads/<hash>.png` and later passed into `@napi-rs/canvas`'s native decoder by the export renderer, so unverified content reaching a native parser was a real, if narrow, gap
- Adds a check of the actual 8-byte PNG magic number after the existing MIME/size checks, so only real PNG bytes get written to disk

## Test plan
- [x] `just check` (typecheck + biome + stars.css freshness) passes
- [x] `just test` passes (49/49), including a new test asserting a spoofed `Content-Type: image/png` with non-PNG bytes is rejected, and the existing "accepts a PNG upload" test updated to use real PNG magic bytes