### PR TITLE
fix: add missing DOCTYPE to prevent quirks mode rendering

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="utf-8">


### PR DESCRIPTION
## Summary
- Brave DevTools flagged the page as rendering in Quirks Mode on the live site
- `client/index.html` was missing `<!DOCTYPE html>`, added it

## Test plan
- [ ] Reload the page and confirm devtools no longer reports Quirks Mode

## Summary by Sourcery

Bug Fixes:
- Prevent the client page from rendering in browser quirks mode by declaring the HTML5 doctype.