### PR TITLE
docs: adopt ASD-STE100 for comments and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,196 +1,311 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file gives guidance to Claude Code (claude.ai/code). Read it before you
+work with code in this repository.
 
 ## What this is
 
-A single-page site that recreates the "shooting stars" meme: a background video plays, and up to 6 images (uploaded by the user, or the default doge image) fly across the screen in sync with hardcoded animation keyframes. No frontend framework, runtime/build tooling is Bun (native CSS/TS bundling, dev-mode HMR, HTTP server), no database — uploaded files on disk are the only state. Written in TypeScript; Bun runs `.ts` files directly (strips types, no compile-to-disk step).
+This project is a single-page site. It recreates the "shooting stars" meme.
+A background video plays. Up to 6 images fly across the screen. The images
+move in time with fixed animation keyframes. The user uploads the images.
+The site shows the default doge image when the user uploads nothing.
+
+The project uses no frontend framework. Bun is the runtime. Bun also bundles
+the CSS and the TypeScript. Bun serves HTTP. Bun gives hot module replacement
+in development mode. The project uses no database. The uploaded files on disk
+hold all of the state.
+
+The code is TypeScript. Bun runs `.ts` files directly. Bun removes the types
+at load time. Bun writes no compiled files to disk.
+
+The site can also export the animation as a video file. The server renders it
+with a native canvas and `ffmpeg`. It uses no headless browser. The output is
+MP4, WebM, or GIF. See `server/export.ts` in Architecture below.
 
 ## Commands
 
-Docker (preferred workflow, via `just`):
+Docker is the preferred workflow. Use `just`:
 ```sh
 just build       # docker compose build
-just start       # docker compose up -d       (production: bun server/server.ts, bundles/minifies/caches lazily at runtime)
-just dev         # docker compose --profile dev up bun-dev  (live HMR via `bun --hot`)
-just check       # tsc --noEmit + biome check + stars.css freshness check, inside the dev container (see Notes — Bun itself doesn't type-check)
-just format      # biome check --write, auto-fixes lint/format issues
-just generate-css # regenerate client/css/stars.css from server/keyframes.ts (see Architecture)
-just up          # build + start
-just shell       # shell into the bun container
-just test        # bun test, inside the dev container
-just down        # stop + remove containers (keeps volumes)
-just down_clean  # stop + remove containers AND volumes
-just lock        # regenerate bun.lock inside the container
+just start       # docker compose up -d. Production. Bun bundles, minifies, and caches at runtime.
+just dev         # docker compose --profile dev up bun-dev. Live HMR through `bun --hot`.
+just check       # tsc --noEmit, biome check, and the stars.css freshness check. Runs in the dev container.
+just format      # biome check --write. Corrects lint and format problems.
+just generate-css # Regenerates client/css/stars.css from server/keyframes.ts. See Architecture.
+just up          # build, then start
+just shell       # Opens a shell in the bun container.
+just test        # bun test, in the dev container
+just test-coverage # bun test --coverage, in the dev container
+just down        # Stops and removes the containers. Keeps the volumes.
+just down_clean  # Stops and removes the containers and the volumes.
+just lock        # Regenerates bun.lock in the container.
+just clean       # Prunes the Docker environment.
 ```
 
-Tests are `bun:test` (`tests/server.test.ts`), invoked via `just test` or
-`bun test` directly (Bun's own test runner — no Jest/Vitest needed). Linting/
-formatting is Biome (`biome.json`), invoked via `just check`/`just format`.
+`package.json` holds the same work as plain scripts: `typecheck`, `lint`,
+`lint:fix`, `generate:css`, `verify:css`, and `check`. `just check` runs
+`bun run check`, which chains the first, the second, and the fifth.
+
+The tests use `bun:test`. They live in `tests/`. There are three files:
+`server.test.ts`, `keyframes.test.ts`, and `animation-timeline.test.ts`. Run
+them with `just test`. You can also run `bun test` directly. Bun supplies its
+own test runner. The project needs no Jest. The project needs no Vitest.
+Biome does the linting and the formatting (`biome.json`). Run it with
+`just check` or `just format`.
 
 ## Configuration
 
-Copy `.env.dist` to `.env` to override `APP_PORT`/`HASH_LENGTH`/`UPLOADS_DIR`/
-`UPLOAD_RETENTION_DAYS`. These are picked up two different ways:
-`HASH_LENGTH`/`UPLOAD_RETENTION_DAYS` flow through `docker-compose.yml`'s
-`env_file:` into the container's `process.env`, for `server.ts` and
-`scripts/clean_old_uploads.sh` to read; `APP_PORT`/`UPLOADS_DIR` are only ever
-read by `docker compose` itself, via plain shell-style `${VAR}` interpolation
-when parsing `docker-compose.yml` — for the host-side port mapping and the
-uploads bind-mount path shared by the `bun`/`bun-dev`/`cleanup` services.
-Both mechanisms read the same `.env` file but are otherwise unrelated
-features of Compose. The app's own listening port is deliberately NOT
-configurable — `server.ts` hardcodes `9595` whether run via `bun server/server.ts`
-directly or inside a container; only the Docker host-side publish port
-(`APP_PORT`, default `9595`) can differ. `.env` is optional, so a missing one
-still works, falling back to `server.ts`'s built-in defaults and to
-`docker-compose.yml`'s own `${VAR:-default}` fallbacks (currently
-`/tmp/shooting-stars-uploads` for `UPLOADS_DIR` — a dedicated subfolder rather
-than bare `/tmp`, so the bind mount doesn't pull in unrelated files already
-sitting in the host's shared `/tmp`; point it at a real persistent host path
-for production). Docker creates the directory itself on first `up` if it
-doesn't exist yet — no manual setup needed — and the `cleanup` service's own
-age-based pruning (see Architecture below) applies to it the same as any
-other path, so there's no extra lifecycle to manage beyond that.
-`NODE_ENV` is deliberately NOT in `.env` — it only appears once in the whole
-project, as
-`ENV NODE_ENV=production` in the `Dockerfile`'s prod stage. That single line
-is load-bearing: it's the one signal Bun.serve checks to switch its
-HTML-import bundler from dev mode (unminified, `/_bun/...` paths) to
-production mode (minified, cached, hashed filenames) — confirmed by testing,
-not an assumption. The `dev` stage sets nothing; Bun already defaults to
-dev-mode bundling when the var is unset.
+Copy `.env.dist` to `.env` to change `APP_PORT`, `HASH_LENGTH`,
+`UPLOADS_DIR`, or `UPLOAD_RETENTION_DAYS`.
+
+Compose reads these variables in two different ways:
+
+- `HASH_LENGTH` and `UPLOAD_RETENTION_DAYS` go through the `env_file:` key in
+  `docker-compose.yml`. Compose puts them in the `process.env` of the
+  container. `server.ts` reads them. `scripts/clean_old_uploads.sh` reads
+  them too.
+- `APP_PORT` and `UPLOADS_DIR` never reach the container. Compose itself
+  reads them when it parses `docker-compose.yml`. Compose expands them as
+  plain shell `${VAR}` text. `APP_PORT` sets the port map on the host.
+  `UPLOADS_DIR` sets the path of the uploads bind mount. The `bun`,
+  `bun-dev`, and `cleanup` services share that mount.
+
+Both mechanisms read the same `.env` file. They are separate Compose features
+in every other way.
+
+The listening port of the application is fixed on purpose. `server.ts`
+hardcodes `9595`. This is true for `bun server/server.ts`. It is also true
+inside a container. Only the publish port on the host can differ. `APP_PORT`
+sets that port. Its default value is `9595`.
+
+`.env` is optional. The project still works without it. `server.ts` then uses
+its own default values. Compose then uses its own `${VAR:-default}` values.
+The current default for `UPLOADS_DIR` is `/tmp/shooting-stars-uploads`. This
+is a dedicated subfolder, not bare `/tmp`. A bare `/tmp` would pull unrelated
+host files into the bind mount. Point `UPLOADS_DIR` at a real persistent host
+path for production. Docker creates the directory on the first `up`. You need
+no manual setup. The `cleanup` service prunes that directory by age, like any
+other path. No other lifecycle work is necessary.
+
+`NODE_ENV` is not in `.env` on purpose. It appears one time in the whole
+project. The production stage of the `Dockerfile` sets
+`ENV NODE_ENV=production`. That single line is load-bearing. `Bun.serve`
+reads this variable to select the mode of its HTML-import bundler.
+Development mode gives unminified output and `/_bun/...` paths. Production
+mode gives minified output, a cache, and hashed filenames. Tests confirmed
+this behavior. It is not an assumption. The `dev` stage sets no value. Bun
+already defaults to development mode bundling when the variable is empty.
 
 ## TypeScript
 
-`tsconfig.json` covers both runtimes in the project with one shared config
-(not worth splitting for a project this size): `"types": ["bun"]` for
-`server/server.ts`'s Bun globals (`Bun`, `process`, `import.meta.dir`), `"lib":
-["ESNext", "DOM", "DOM.Iterable"]` for the `client/*.ts` files' browser globals
-(`document`, `window`, etc.). Note `"types": ["bun"]` is required, not
-optional — omitting it entirely (relying on TS's default "auto-include every
-`@types/*` package") does NOT pick up `@types/bun`'s ambient globals, even
-though it does still resolve regular module imports like `randomstring` fine
-(confirmed by testing: without it, `Bun`/`process`/`import.meta.dir` are all
-unresolvable errors). `@types/randomstring` needs no entry in `"types"` since
-that only gates ambient/global declarations, not normal `import` resolution.
+One shared `tsconfig.json` covers both runtimes in the project. A project of
+this size does not need two configurations.
 
-Bun strips TypeScript syntax at load time but does **not** type-check —
-`bun --hot server/server.ts` / `bun server/server.ts` will happily run code with type
-errors. `just check` (`tsc --noEmit`, no emit since Bun never reads compiled
-output, plus `biome check`) is the only thing that actually catches them;
-it isn't wired into `just build`/`just dev` automatically.
+- `"types": ["bun"]` supplies the Bun globals for `server/server.ts`. These
+  globals are `Bun`, `process`, and `import.meta.dir`.
+- `"lib": ["ESNext", "DOM", "DOM.Iterable"]` supplies the browser globals for
+  the `client/*.ts` files. Examples are `document` and `window`.
+
+`"types": ["bun"]` is necessary. It is not optional. TypeScript by default
+includes every `@types/*` package. That default does not supply the ambient
+globals of `@types/bun`. The default does still resolve normal module
+imports. Tests confirmed this. Without the entry, TypeScript cannot resolve
+`Bun`, `process`, or `import.meta.dir`. The `"types"` list controls ambient
+declarations only. It does not control `import` resolution. A package that
+ships its own types therefore needs no entry there.
+
+`"resolveJsonModule": true` is also load-bearing. `client/script.ts` imports
+`version` from `package.json` to print the application version in the footer.
+
+Bun removes TypeScript syntax at load time. Bun does **not** check types.
+`bun server/server.ts` runs code that has type errors. `bun --hot
+server/server.ts` does the same. Only `just check` finds these errors. It
+runs `tsc --noEmit` and `biome check`. It emits no files, because Bun never
+reads compiled output. `just build` does not run it. `just dev` does not run
+it either.
 
 ## Linting/formatting
 
-Biome (`biome.json`) replaces the usual ESLint+Prettier pair — one tool,
-one config, no plugins needed for a project this size. The linter runs the
-full `recommended` preset with no rule overrides, and the formatter uses
-Biome's defaults throughout (including double-quote strings — there's no
-project-specific `javascript.formatter` override).
+Biome (`biome.json`) replaces the usual pair of ESLint and Prettier. It is
+one tool with one configuration. A project of this size needs no plugins.
 
-`style/noDescendingSpecificity` was overridden at one point (before
-`client/style.css` was split into `client/css/*.css` — see Architecture
-below). The rule flags a lower-specificity selector defined after a
-higher-specificity one for a related selector; each flagged case so far has
-been two selectors that never actually collide in the cascade (an ID-scoped
-override rule vs. an unrelated plain class), so the fix is a pure reorder —
-move the lower-specificity rule earlier in the file — never a behavior
-change, since the higher-specificity selector already wins regardless of
-source order. `@layer` ordering (see Architecture below) does **not** make
-this rule droppable on its own — Biome's specificity check is static and
-doesn't model `@layer` semantics at all (confirmed by testing: removing the
-override with `@layer`s in place still raised the same warnings, until the
-underlying selectors were reordered).
+The linter runs the full `recommended` preset. It overrides no rules. The
+formatter uses the Biome default values everywhere. These defaults include
+double-quote strings. The project adds no `javascript.formatter` override.
 
-CSS formatting/linting is enabled (default), which reformats `@keyframes`
-rules from compact one-liners into one-property-per-line — purely cosmetic,
-no behavior change.
+The project overrode `style/noDescendingSpecificity` at one time. This was
+before the split of `client/style.css` into `client/css/*.css`. See
+Architecture below. The rule flags a selector of low specificity after a
+related selector of high specificity. Every flagged case so far held two
+selectors that never collide in the cascade. One was an override rule with an
+ID. The other was an unrelated plain class. The correction is therefore a
+pure reorder. Move the rule of low specificity earlier in the file. The
+behavior never changes. The selector of high specificity already wins at any
+source position.
 
-`vcs.useIgnoreFile: true` needs an actual `.gitignore` present to work, so
-it's bind-mounted into `bun-dev` alongside the other source paths — without
-it, `biome check` fails outright inside the container (confirmed by
-testing) rather than silently skipping the exclusion.
+The `@layer` order does **not** make this rule safe to drop. The specificity
+check of Biome is static. It does not model `@layer` semantics. Tests
+confirmed this. The same warnings appeared with the layers in place. The
+warnings stopped only after a reorder of the underlying selectors.
+
+CSS formatting and linting are on. This is the default. Biome rewrites
+compact one-line `@keyframes` rules into one property per line. This change
+is cosmetic. It changes no behavior.
+
+`vcs.useIgnoreFile: true` needs a real `.gitignore` file. Compose therefore
+bind-mounts `.gitignore` into `bun-dev` with the other source paths. Without
+that file, `biome check` fails in the container. Tests confirmed this. It
+does not skip the exclusion quietly.
 
 ## Architecture
 
-The repo is split into `server/` (Bun backend) and `client/` (everything Bun's
-HTML-import bundler processes), plus `scripts/` (ops tooling) and `tests/` —
-project-level config (`Dockerfile`, `docker-compose.yml`, `justfile`,
-`package.json`, `tsconfig.json`, `biome.json`, `.env.dist`) stays at the root.
+The repository has these top-level parts:
 
-- **`server/server.ts`** — the entire backend, built around `Bun.serve()`:
-  - `import index from '../client/index.html'` — Bun's HTML-import bundling parses `index.html`, discovers its linked `client/style.css`/`client/script.ts`/bundled assets, and bundles them. Whether this happens in dev mode (on-demand, unminified, HMR) or production mode (minified, cached, hashed filenames) is decided by Bun itself purely from the `NODE_ENV` env var (`production` → prod bundling, anything else → dev bundling) — `server.ts` has no explicit dev/prod branching of its own for this.
-  - `routes` table: `'/'` and the wildcard `'/*'` both serve the `index` HTML bundle (the wildcard is the SPA-style fallback for an uploaded-image hash path like `/abc12` — the hash is read client-side from `location.pathname`, not routed server-side). These two routes can't be wrapped for logging: Bun's HTML-bundle value can only be returned by direct assignment (`'/': index`), not from inside a route handler function — returning it from a function silently produces a bogus placeholder response instead (tested against Bun 1.3.14). Every other route is a plain function and does get logged.
-  - `'/upload'` has a `POST` handler that reads the file via `req.formData()` (native multipart parsing, no `multer`) and writes it to `uploads/` via `Bun.write()` under a `randomstring`-generated name (length controlled by `HASH_LENGTH` env var), then redirects to `/<hash>`. Only accepts `image/png` under `MAX_UPLOAD_SIZE` (15MB, generous — `$toCanvas()` renders at source-image resolution, not the crop zone's display size, so a large original photo can still produce a large PNG) — the client's preview dialog (see `client/preview.ts` below) always crops and re-encodes through `<canvas>` before uploading, regardless of the source file's original format, so PNG is the only type that's ever legitimately sent. `EXTENSION_BY_MIME`/`KNOWN_SUFFIXES` still list the older accepted types (jpg, gif, webp, svg, etc.) purely so uploads made before this restriction keep resolving/serving correctly under `/uploads/*` — that map is no longer consulted on the write path, only by `resolveUpload()`. Rejections redirect to `/?error=<reason>` (`invalid_type` or `too_large`) instead of a bare `/`, so the client can show a specific message (see `client/preview.ts` below) rather than failing silently.
-  - `'/uploads/*'` serves files from `uploads/` via `Bun.file()`. `'/img/*'` similarly serves `client/public/img/` — needed because `script.ts` references `img/doge.png` dynamically at runtime (a plain string, not statically analyzable), so the HTML bundler can't pick it up the way it does the video/CSS/JS. `'/videos/*'` serves `client/public/videos/` for the same reason but a different cause: the HTML bundler processes `<video><source src>` but does NOT process a sibling `<track src>` on that same element (confirmed by testing — the `<source>`'s path gets rewritten to a hashed `/_bun/asset/...` URL, the `<track>`'s doesn't), so the video's captions `.vtt` file needs its own manual route rather than riding along with `background.mp4`. All three go through `serveFrom()`, whose `../` path-traversal safety was verified by testing (plain, percent-encoded, and double-encoded traversal attempts all correctly blocked) — it relies on `new URL().pathname` normalizing dot segments before the path is sliced, so don't switch that to raw `req.url` string matching without re-verifying.
-  - A few security response headers (`X-Content-Type-Options`, `X-Frame-Options`, a basic CSP) are set on every response we build ourselves — no `helmet` dependency needed for this. Not applied to the HTML-bundle routes (`'/'`/`'/*'`) since Bun's HTML-import routing doesn't expose a documented way to attach custom headers to those.
-  - `log()` is a tiny timestamped `console.log` wrapper used for startup info, every upload attempt (success with filename/type/size, or rejection reason), every static file serve/404 under `/uploads/*`, `/img/*`, and `/videos/*`, and uncaught errors (via Bun.serve's `error` hook). The two HTML-bundle routes are the one place that can't be logged per-request, per the limitation above.
-  - Bun loads `.env` files natively — no `dotenv`.
-  - `uploadsDir`, the `/img/*` static folder (`${import.meta.dir}/../client/public/img`), and the `/videos/*` static folder (`${import.meta.dir}/../client/public/videos`) all resolve relative to `server.ts`'s own location, since `uploads/` and `client/` are siblings of `server/`, not nested inside it.
-  - The `Bun.serve()` return value is kept (`const server = ...`) and `export default`ed purely so `tests/server.test.ts` can `fetch()` against it directly, in-process — not used by `server.ts` itself otherwise.
-  - `'/export/*'` renders the shooting-stars animation server-side as MP4 (H.264 + AAC, audio copied straight from `background.mp4`) or WebM (VP8 + Vorbis, both re-encoded since WebM can't carry AAC) depending on a `?format=mp4|webm` query param (`server/export.ts`, `@napi-rs/canvas` + a single `ffmpeg` process, no headless browser) — see `server/keyframes.ts` below for the animation data it's built from. WebM is noticeably slower to encode than MP4 (VP8 vs. `libx264 -preset ultrafast`, even at `-deadline realtime -cpu-used 8`) but still finishes in single-digit seconds, not GIF's old ~10-62s. The actual rendering runs in a separate OS thread (`renderExportInWorker()`, `server/export-worker.ts`), not on `Bun.serve`'s own thread — `@napi-rs/canvas`'s per-frame drawing is synchronous native CPU work (unlike the `ffmpeg` subprocess, already off-thread via `Bun.spawn`), so without a worker thread a render would block every other request (page loads, uploads, other exports' progress polls) for the whole render duration. Confirmed by testing: `GET /` still answers in ~1ms while an export renders. The worker communicates back over `parentPort.postMessage()` (progress ticks, then a final `done`/`error`) rather than a return value; it's left to exit on its own once it posts its result — forcibly `worker.terminate()`-ing it from the main thread raced that natural exit and printed a spurious Bun "ObjectRef is not unref" warning on every export.
-  - `'/export-status'` reports `{ inProgress, percent }` (module-level state updated once per rendered frame in `renderExport`'s `onProgress` callback) so `client/export.ts` can poll real progress during a render and drive a `<progress>` bar in a dedicated modal `<dialog>` (`#export-progress-dialog`, opened with `showModal()`) rather than a bare spinner — the modal also makes the rest of the page inert for free while a render is in flight, and its `cancel` event is `preventDefault()`-ed so Escape can't dismiss it mid-render (there's no cancel-in-flight support). Deliberately a top-level path, not nested under `/export/`, so it can never collide with that route's wildcard hash matching.
+- `server/` holds the Bun backend.
+- `client/` holds everything that the HTML-import bundler of Bun processes.
+- `scripts/` holds the operations tools.
+- `tests/` holds the tests.
 
-- **`server/keyframes.ts`** — the canonical animation dataset for the export renderer, and (via `scripts/generate-stars-css.ts` below) for `client/css/stars.css` too. Each entry in `ANIMATIONS` is a `PictureAnimation`: per-property control-point arrays (`x`/`y`/`scaleX`/`scaleY`/`rotateDeg`/`opacity`/`filter`) plus a `transformOrder` (`"scale-rotate"` or `"rotate-scale"`) recording which order that specific animation composes its CSS transform functions in — `stars.css` isn't consistent about this (`spaceone`/`dolphins-two` write `translate() scale() rotate()`, the rest write `translate() rotate() scale()`), and since CSS composes transform functions in written order, `server/export.ts`'s canvas rendering has to replicate whichever order each animation actually uses, not one fixed order. A control point can carry `implicit: true` to mark a synthetic identity value added purely so `resolvePictureFrame()`'s linear interpolation has a boundary to interpolate from (e.g. `spacetwo_3`'s transform/filter don't start until 50% in the source CSS; the leading 0% point exists only for the math) — `interpolate()`/`interpolateFilter()` ignore the flag, but `scripts/generate-stars-css.ts` reads it to know not to emit that property at that percentage. This file is meant to be edited directly (unlike `stars.css`); after editing, run `just generate-css` to regenerate `client/css/stars.css`, since `just check` will otherwise fail (see Linting/formatting above).
+The project configuration files stay at the root. These are `Dockerfile`,
+`docker-compose.yml`, `justfile`, `package.json`, `tsconfig.json`,
+`biome.json`, and `.env.dist`.
 
-- **`server/export-worker.ts`** — the worker-thread entry point spawned by `renderExportInWorker()` in `server/export.ts` (see above), so it's a thin wrapper, not a separate implementation: reads its job (`imagePath`/`orientation`/`format`/`dir`) from `worker_threads`' `workerData`, calls the same `renderExport()` the direct (non-worker) path would, and reports back over `parentPort.postMessage()` since a worker's result is message-based, not a return value.
+- **`server/server.ts`** — the whole backend. It is built around `Bun.serve()`:
+  - `import index from '../client/index.html'` — the HTML-import bundling of Bun parses `index.html`. It finds the linked `client/style.css`, the linked `client/script.ts`, and the other assets. It bundles all of them. Bun alone selects the bundling mode. It reads the `NODE_ENV` variable. A value of `production` selects production bundling: minified, cached, hashed filenames. Any other value selects development bundling: on demand, unminified, with hot module replacement. `server.ts` holds no branch of its own for this.
+  - The `routes` table: `'/'` and the wildcard `'/*'` both serve the `index` HTML bundle. The wildcard is the fallback in the style of a single-page application. It catches a path with an upload hash, such as `/abc12`. The client reads that hash from `location.pathname`. The server does not route it. You cannot wrap these two routes for logging. Bun accepts the HTML bundle value only by direct assignment, as in `'/': index`. A route handler function cannot return it. A function return gives a placeholder response instead, with no error. Tests confirmed this against Bun 1.3.14. Every other route is a plain function. The logger records all of those.
+  - `'/upload'` has a `POST` handler. It reads the file with `req.formData()`. Bun parses the multipart body natively. The project needs no `multer`. The handler runs three checks in order. First it requires a `Blob` with a `file.type` of exactly `image/png`. Second it enforces `MAX_UPLOAD_SIZE` (15MB). Third it calls `hasPngSignature()`, which compares the first 8 bytes against the PNG magic number. That third check is the real gate. `file.type` is only the Content-Type that the client declares, so a raw `POST` can spoof it. The stored file later reaches the native image decoder of the export renderer, so bad bytes must never land on disk. The size limit is generous on purpose. `$toCanvas()` renders at the resolution of the source image. It does not render at the display size of the crop zone. A large source photograph can therefore make a large PNG file.
+  - `generateUploadHash()` names the stored file. `randomHash()` builds the name from `HASH_CHARS` with `randomInt` from `node:crypto`. The project uses no `randomstring` dependency any more. `HASH_LENGTH` sets the length. The function retries up to `MAX_HASH_ATTEMPTS` (5) times on a collision with an existing file. It then accepts the last name and overwrites. The collision odds are about 1e-8 at the default length. `Bun.write()` writes the file into `uploads/` as `<hash>.png`. The handler then redirects to `/<hash>`.
+  - The preview dialog of the client always crops the image. It also re-encodes the image through a `<canvas>` element. It does this for every source format. PNG is therefore the only type that a legitimate upload sends. See `client/preview.ts` below. `EXTENSION_BY_MIME` and `KNOWN_SUFFIXES` still list the older accepted types, such as jpg, gif, webp, and svg. They keep old uploads readable under `/uploads/*`. Those uploads came before the PNG restriction. The write path no longer reads that map. Only `resolveUpload()` reads it. `sniffLegacyContentType()` covers the oldest uploads, which carry no extension at all. It reads the first bytes to recognize an SVG. A browser refuses to render an SVG inline without the correct header. A rejection redirects to `/?error=<reason>`. The reason is `invalid_type` or `too_large`. A bare `/` would hide the cause. The client shows a specific message instead. It does not fail silently.
+  - `'/uploads/*'` serves files from `uploads/` with `Bun.file()`. `'/img/*'` serves `client/public/img/`. This route is necessary because `script.ts` names `img/doge.png` at runtime as a plain string. The bundler cannot analyze that string. It therefore cannot handle the file as it handles the video, the CSS, and the JavaScript. `'/videos/*'` serves `client/public/videos/`. The cause here is different. The bundler processes `<video><source src>`. The bundler does not process a `<track src>` on the same element. Tests confirmed this. The bundler rewrites the path of the `<source>` to a hashed `/_bun/asset/...` URL. The bundler leaves the path of the `<track>` alone. The captions `.vtt` file therefore needs its own manual route. All three routes call `serveFrom()`. Tests verified its protection against `../` path traversal. Plain, percent-encoded, and double-encoded attempts were all blocked. The protection depends on `new URL().pathname`. That property normalizes the dot segments before the code slices the path. Do not replace it with a match on the raw `req.url` string. Verify the protection again first.
+  - The server sets a few security headers on every response that it builds. These are `X-Content-Type-Options`, `X-Frame-Options`, and a basic CSP. The project needs no `helmet` dependency for this. The HTML bundle routes `'/'` and `'/*'` do not get these headers. The HTML-import routing of Bun has no documented way to attach custom headers to them.
+  - `log()` is a small wrapper around `console.log`. It adds a timestamp. It records the startup information. It records every upload attempt. A success line holds the filename, the type, and the size. A rejection line holds the reason. It records every static file serve and every 404 under `/uploads/*`, `/img/*`, and `/videos/*`. It also records uncaught errors, through the `error` hook of `Bun.serve`. The two HTML bundle routes are the one place with no per-request log, for the reason above.
+  - Bun loads `.env` files natively. The project needs no `dotenv`.
+  - `uploadsDir` resolves relative to the location of `server.ts`. The `/img/*` folder (`${import.meta.dir}/../client/public/img`) does the same. The `/videos/*` folder (`${import.meta.dir}/../client/public/videos`) does the same. `uploads/` and `client/` are siblings of `server/`. They are not inside it.
+  - The code keeps the return value of `Bun.serve()` as `const server`. It also exports it as the default export. Only `tests/server.test.ts` needs this. The test calls `fetch()` against the server directly, in the same process. `server.ts` does not use the value itself.
+  - `'/export/*'` renders the shooting-stars animation on the server. `server/export.ts` holds this code. It uses `@napi-rs/canvas` and one `ffmpeg` process. It needs no headless browser. See `server/keyframes.ts` below for the animation data. `parseExportOptions()` reads four query parameters: `orientation`, `resolution`, `fps`, and `format`. It falls back to a default for any value outside the allowed set. The defaults are `landscape`, `480p`, `24`, and `mp4`. The allowed sets live in `client/export-options.ts`. See that bullet below.
+  - The three export formats are MP4, WebM, and GIF. MP4 holds H.264 video and AAC audio. The encoder copies that audio straight from `background.mp4`. WebM holds VP8 video and Vorbis audio. The encoder re-encodes both of them, because WebM cannot carry AAC. WebM encodes much slower than MP4. VP8 is slower than `libx264 -preset ultrafast`. This stays true with `-deadline realtime -cpu-used 8`. GIF is the slowest of the three. It carries no audio. It needs a `palettegen` pass and a `paletteuse` pass for acceptable quality. Its filter graph, its map arguments, and its tail arguments therefore differ from the two video formats. `paletteuse` runs a Bayer dither at `bayer_scale=5`. The default `sierra2_4a` dither measured about 29% larger with no visible quality gain.
+  - GIF also takes its own caps, through `clampForGif()`. The caps are 480p and 24fps. The server applies them in `parseExportOptions()`, not the client alone. A direct request could otherwise pass them. An uncapped GIF at 1080p and 60fps measured about 146s and about 324MB. WebM at the same settings measured about 20s and about 6MB. The renderer applies no automatic downscale beyond that cap. The client shows a real size estimate first instead. See `client/export.ts` below.
+  - `idleTimeout` is 60 seconds. The Bun default of 10 seconds is too short. The server streams nothing. It sends one `Response` after the whole render, so the render duration counts against the timeout. A module-level `exportInProgress` flag is a single-slot lock. A second request during a render gets a 429 status. A real job queue is not worth the code for how rarely two exports overlap. The response carries a `Content-Disposition` filename of `<hash>.<format>`, or `doge.<format>` for the default image. A fixed name would make two exports collide on disk.
+  - `renderExportInWorker()` runs the render on a separate operating system thread. `server/export-worker.ts` is that thread. The render does not run on the thread of `Bun.serve`. The per-frame drawing of `@napi-rs/canvas` is synchronous native CPU work. The `ffmpeg` subprocess is already off the thread, through `Bun.spawn`. Without a worker thread, a render would block every other request for its full duration. Page loads, uploads, and progress polls would all stop. Tests confirmed the correction: `GET /` still answers in about 1 ms during a render. The worker reports back with `parentPort.postMessage()`. It sends progress ticks. It then sends a final `done` message or `error` message. It does not return a value. The main thread lets the worker exit by itself. A forced `worker.terminate()` raced that natural exit. It also printed a false Bun warning about "ObjectRef is not unref" on every export.
+  - `'/export-status'` reports `{ inProgress, percent }`. Module-level state holds these values. The `onProgress` callback of `renderExport` updates them once per rendered frame. `client/export.ts` polls this route during a render. It drives a `<progress>` bar with the result. The bar lives in a modal `<dialog>` element, `#export-progress-dialog`. The client opens it with `showModal()`. A plain spinner would show no real progress. The modal also makes the rest of the page inert during a render. The code calls `preventDefault()` on the `cancel` event of the dialog. The Escape key therefore cannot close the dialog during a render. The project supports no cancel of a render in flight. This route is a top-level path on purpose. It is not under `/export/`. It can therefore never collide with the wildcard hash match of that route. The per-frame progress stops at `FRAME_PROGRESS_CAP` (95), not at 100. `ffmpeg` still encodes after the last frame arrives, and the GIF palette passes run long after that point. `renderExport()` reports the real 100 after the process exits.
 
-- **`client/index.html`** (Bun's HTML-import entry point) — links `./style.css` and `./script.ts` via plain relative paths (siblings in the same folder), and the background video via `./public/videos/background.mp4` (a real relative path so Bun's bundler picks it up, copies it, and rewrites the URL — referencing it as `/videos/background.mp4` instead makes the bundler try and fail to resolve it as a module). The favicon `<link>` is one asset-looking tag Bun's bundler does NOT process at all, so it keeps a plain `/img/favicon.png` server-relative href, served by the `/img/*` route. The video's `<track kind="captions" src="/videos/background.vtt">` (needed to satisfy `a11y/useMediaCaption`, see Linting/formatting above) is the same story: it's a plain server-relative href rather than a bundler-relative `./` path, served by the `/videos/*` route (see `server.ts` above) — the captions file itself is just a header-only `WEBVTT` with no cues, since the video has no dialogue to transcribe (it does play quiet audio, `animation.ts` sets `video.volume = 0.05`, so `muted` — the rule's other exemption — isn't an option here).
+- **`server/keyframes.ts`** — the canonical animation dataset. The export renderer reads it. `scripts/generate-stars-css.ts` also reads it to write `client/css/stars.css`. Each entry in `ANIMATIONS` is a `PictureAnimation`. It holds one control-point array per property: `x`, `y`, `scaleX`, `scaleY`, `rotateDeg`, `opacity`, and `filter`. It also holds a `transformOrder` value of `"scale-rotate"` or `"rotate-scale"`. That value records the order of the CSS transform functions for that one animation. `stars.css` is not consistent here. `spaceone` and `dolphins-two` write `translate() scale() rotate()`. The other animations write `translate() rotate() scale()`. CSS composes transform functions in written order. The canvas rendering in `server/export.ts` must therefore follow the order of each animation. One fixed order is not correct. A control point can carry `implicit: true`. This flag marks a synthetic identity value. The linear interpolation in `resolvePictureFrame()` needs a boundary to interpolate from. For example, the transform and the filter of `spacetwo_3` start at 50% in the source CSS. The leading 0% point exists only for the arithmetic. `interpolate()` and `interpolateFilter()` ignore the flag. `scripts/generate-stars-css.ts` reads the flag. It then omits that property at that percentage. Edit this file directly. Do not edit `stars.css`. Run `just generate-css` after an edit. `just check` fails otherwise. See Linting/formatting above.
 
-- **`client/script.ts`** — page bootstrap, no bundler-specific APIs beyond being loaded as an ES module (`type="module"`) and importing its sibling modules. Reads the current URL path: if it's `/` shows `img/doge.png`, otherwise treats the path as an uploaded image hash and points all 6 `<img>` elements at `uploads/<hash>`, then creates the 6 `<img id="pict1">` through `<img id="pict6">` elements themselves. Also owns the file-upload-focus class trick (`#file-upload` can't rely on CSS's adjacent-sibling focus trick since it has two labels in different parts of the DOM — see `body.file-upload-focused` in `client/css/buttons.css`), and wires `initPreviewDialog(applyUploadedImage)` (see `client/preview.ts` below). `applyUploadedImage()` is the callback passed into `initPreviewDialog()`: on a successful upload it swaps the 6 pictures' `src`, `history.pushState()`s the new `/<hash>` URL, and calls `startAnimation()` (imported from `client/animation.ts` below) directly — no full page reload. The actual choreography engine lives in `animation.ts`, not here — this file's only ties to it are the `restartAnimation()`/`startAnimation()` imports/calls.
+- **`server/export-worker.ts`** — the entry point of the worker thread. `renderExportInWorker()` in `server/export.ts` starts it. See above. It is a thin wrapper, not a second implementation. It reads its job from the `workerData` of `worker_threads`. The job holds `imagePath`, `orientation`, `format`, and `dir`. It calls the same `renderExport()` that the direct path calls. It reports back with `parentPort.postMessage()`. The result of a worker is a message, not a return value.
 
-- **`client/animation.ts`** — the shooting-stars choreography engine, split out of `script.ts` since it's a self-contained concern (launch-prompt gating + the timed picture/video sequence) with its own DOM refs (`video`, `landing`, `starfield`, `tap-to-play`) and module state (`animationTimeouts`, `launchListenersAttached`), unrelated to `script.ts`'s one-time bootstrap work. `startAnimation()`'s loop drives off `ANIMATION_TIMELINE`, imported from `client/animation-timeline.ts` (see below) rather than defined inline, so both this module and the server-side export renderer read the exact same stage timeline. DOM lookups use `as Type` casts (`document.getElementById('video') as HTMLVideoElement`, etc.) rather than defensive null checks, since these are static elements always present in `index.html` — a cast, not a bare `!` non-null assertion, since `noNonNullAssertion` is enforced (see Linting/formatting above) and only the latter trips it. `startAnimation()` is only ever wired to `#tap-to-play` itself (a real `<button>`, not `window`) — clicking/tapping/keyboard-activating that one element is the only way to launch, no target-filtering guard needed since nothing else can reach the listener. Exports `restartAnimation`/`startAnimation` for `script.ts` to call; wires `video`'s own `'ended'` listener (→ `restartAnimation`) itself at module load, since that's part of this module's own lifecycle rather than the bootstrap's.
+- **`client/index.html`** — the entry point for the HTML import of Bun. It holds the whole page as static markup: `#starfield`, the `<video>` element, the hidden upload `<form>`, the `#quick-actions` dock, the `#landing` console, the `#upload-error` toast, three `<dialog>` elements, `#pictures-container`, and the footer. The three dialogs are `#preview-dialog`, `#export-options-dialog`, and `#export-progress-dialog`. `client/script.ts` creates only the 6 `<img>` elements. Every other element already exists here, which is why the TypeScript modules cast their DOM lookups instead of checking for null. The `<head>` also carries the Open Graph tags. `og:image` points at an absolute `https://shooting-stars.tekrop.fr/img/preview.jpg` URL, because a social crawler cannot resolve a relative one.
+  - It links `./style.css` and `./script.ts` with plain relative paths. Both files are siblings in the same folder. It links the background video as `./public/videos/background.mp4`. This real relative path lets the bundler find the file. The bundler then copies the file and rewrites the URL. A `/videos/background.mp4` path instead makes the bundler treat the file as a module. That attempt fails. The favicon `<link>` looks like an asset tag. The bundler does not process it at all. It therefore keeps a plain server-relative `/img/favicon.png` href. The `/img/*` route serves it. The video carries `<track kind="captions" src="/videos/background.vtt">`. This tag satisfies `a11y/useMediaCaption`. See Linting/formatting above. It is the same story as the favicon. It uses a plain server-relative href, not a bundler-relative `./` path. The `/videos/*` route serves it. See `server.ts` above. The captions file holds only a `WEBVTT` header and no cues. The video has no dialogue to transcribe. The video does play quiet audio. `animation.ts` sets `video.volume = 0.05`. A `muted` attribute is the other exemption of the rule. It is therefore not an option here.
 
-- **`client/animation-timeline.ts`** — pure data, no DOM access: `AnimationStage` type and `ANIMATION_TIMELINE` (millisecond offsets → which stage class applies and which `pictN` ids are visible), split out of `animation.ts` specifically so `server/export.ts` can import the timeline without pulling in `animation.ts`'s top-level `document.getElementById(...)` calls, which throw outside a browser (e.g. under `bun test`). This map's timings must still line up with `videos/background.mp4`'s runtime and with the animation durations defined in `client/css/stars.css` by hand — nothing derives one from the other.
+- **`client/script.ts`** — the page bootstrap. It uses no bundler-specific API. The page loads it as an ES module, through `type="module"`. It imports its sibling modules. It reads the current URL path. A `/` path shows `img/doge.png`. Any other path is an upload hash. The file then points all 6 `<img>` elements at `uploads/<hash>`. It creates those 6 elements itself, with the ids `pict1` through `pict6`. This file also owns the focus class trick for the upload control. `#file-upload` has two labels in different parts of the DOM. It therefore cannot use the adjacent-sibling focus selector of CSS. See `body.file-upload-focused` in `client/css/buttons.css`. It also runs the three initializers: `initPreviewDialog(applyUploadedImage)`, `initExport()`, and `initVolumeControl()`. `applyUploadedImage()` is the upload callback. A successful upload runs it. The callback swaps the `src` of the 6 pictures. It pushes the new `/<hash>` URL with `history.pushState()`. It then calls `startAnimation()` from `client/animation.ts`. The page never reloads. The choreography engine lives in `animation.ts`, not here. This file only imports and calls `restartAnimation()` and `startAnimation()`. This file also owns two small pieces of page chrome. It writes the application version into the footer, from the `version` field of `package.json`. It also owns the `#copy-link-btn` handler. That handler writes `location.href` through `navigator.clipboard`. It reports a missing clipboard API and a denied permission as two separate messages. Clipboard access needs a secure context, so both cases happen in practice.
 
-- **`client/preview.ts`** — the pre-upload preview dialog: file picked → crop step → optional transparency-editing step → upload. Uses [`cropperjs`](https://github.com/fengyuanchen/cropperjs) (v2, the Web Components rewrite — `new Cropper(image, { container })` renders a `<cropper-canvas>` tree of custom elements, not a single widget) for the crop step, driven through its `$`-prefixed instance API (`$ready`, `$center`, `$scale`, `getCropperSelection()`, `$change`, `$toCanvas`) rather than DOM attributes. On crop-step init, the image is sized to `IMAGE_FIT_SCALE` (80%) of the crop zone via `$center('contain').$scale(...)`, and the selection is immediately `$change()`'d to match the image's own rendered bounds exactly (read back via `getBoundingClientRect()` on the image vs. the canvas) — cropperjs's own `initial-coverage` option sizes the selection against the *canvas*, not the image, so without this a full-coverage selection would include the empty letterboxed margin as extra transparent space whenever the image and crop zone aspect ratios don't match. `(getCropperSelection() as CropperSelection).$toCanvas()` renders the crop result into `#edit-canvas`, handing off to `initTransparencyTools()` (see below) for the second step. Final upload always goes out as `cropped.png` via `fetch('/upload', ...)` regardless of whether the user touched the transparency tools, since the server only accepts PNG (see `server.ts` above). `fetch` follows the 303 itself, so the outcome is read from the final `res.url`/`res.status` rather than the redirect header directly: a hash-shaped path means success (dialog closes, `onUploaded(hash)` callback fires — no navigation); a bare `/` with an `error` query param, a `>=500` status, or a thrown/rejected `fetch` (network failure) all close the dialog and show a reason-specific message via `#upload-error` (a dismissible, auto-timeout toast — see `UPLOAD_ERROR_MESSAGES`) instead of reloading the page or failing silently.
+- **`client/animation.ts`** — the shooting-stars choreography engine. It was part of `script.ts` before. It is a self-contained concern: the launch prompt gate plus the timed picture and video sequence. It owns its own DOM references: `video`, `landing`, `starfield`, and `tap-to-play`. It owns its own module state: `animationTimeouts` and `launchListenersAttached`. None of this belongs to the one-time bootstrap work in `script.ts`. The loop in `startAnimation()` drives off `ANIMATION_TIMELINE`. It imports that value from `client/animation-timeline.ts`. See below. This module and the export renderer of the server therefore read the same stage timeline. The DOM lookups use `as Type` casts, such as `document.getElementById('video') as HTMLVideoElement`. They use no defensive null check. These elements are static. `index.html` always holds them. A cast is correct here. A bare `!` assertion is not. `noNonNullAssertion` is on, and it flags only the assertion. See Linting/formatting above. `#tap-to-play` is the only element wired to `startAnimation()`. It is a real `<button>` element, not `window`. A click, a tap, or a keyboard press on that one element is the only launch path. The listener needs no target filter. Nothing else can reach it. The module exports `restartAnimation` and `startAnimation` for `script.ts`. It wires the `'ended'` listener of `video` to `restartAnimation` itself, at module load. That listener belongs to the lifecycle of this module, not to the bootstrap.
 
-- **`client/transparency.ts`** — the optional second dialog step: erase (drag a brush, `globalCompositeOperation: 'destination-out'`) or color-pick (click a pixel, clear every pixel within a Euclidean-RGB-distance tolerance via `ImageData`) to make parts of the cropped canvas transparent. Both tools share one undo/redo stack of `ImageData` snapshots (capped at `MAX_HISTORY`, taken once per pointerdown so a whole drag is one undo step, not one per brush dab). `initTransparencyTools()` returns a `reset()` used by `preview.ts` to clear tool/history state each time a fresh crop lands in `#edit-canvas`.
+- **`client/animation-timeline.ts`** — pure data. It touches no DOM. It exports the `AnimationStage` type. It exports `ANIMATION_TIMELINE`. That map turns millisecond offsets into a stage class plus the list of visible `pictN` ids. This file was part of `animation.ts` before. The split lets `server/export.ts` import the timeline alone. `animation.ts` calls `document.getElementById(...)` at the top level. Those calls throw outside a browser, for example under `bun test`. Keep the timings of this map in step with the runtime of `videos/background.mp4`. Keep them in step with the animation durations in `client/css/stars.css` too. You must do this by hand. No file derives its values from another.
 
-- **`client/style.css`** — a thin manifest, not a stylesheet in its own right: declares the cascade layer order (`@layer base, components, dialog, stars, responsive;`) and `@import`s each domain file below from `client/css/`. `index.html` still links this one file directly (`./style.css`); Bun's bundler (Lightning CSS) resolves and inlines the `@import`s into a single bundled stylesheet at build/serve time — confirmed by testing (dev-mode bundle output), not an assumption. Layer order is what actually matters here: a later layer's rules win over an earlier layer's regardless of selector specificity or source order, which is what lets `css/responsive.css` (last) reliably override `css/buttons.css`/`css/landing.css` (`components`) without fighting ID-vs-class specificity.
-  - **`client/css/base.css`** (`layer: base`) — global page chrome that's always present regardless of screen: `:root` theme variables, `html`/`body` reset, `#starfield`, the background `video#video` element and `#pictures-container`, and the persistent `footer`.
-  - **`client/css/buttons.css`** (`layer: components`) — shared button chrome used both on the landing screen and persistently during playback: `.console-btn` (+ `--primary`/`--secondary` variants), `#quick-actions`/`.dock-btn`, and the hidden `#file-upload` input + its focus-ring trick.
-  - **`client/css/landing.css`** (`layer: components`) — the idle-state UI: `#landing`, `.console-card` and its contents, `#upload-error`.
-  - **`client/css/dialog.css`** (`layer: dialog`) — the upload preview dialog: crop/edit steps, `.tool-picker`, `.slider-control`, `.preview-actions`.
-  - **`client/css/stars.css`** (`layer: stars`) — the actual shooting-stars animation, expressed as native CSS `@keyframes` per stage (`init`, `spaceone`, `dolphins`, `spacetwo`, `microone`, `microtwo`). Each stage has per-picture keyframe variants (e.g. `spacetwo_1` through `spacetwo_6`) with different transform/timing so images don't move identically. **This file is generated, not hand-edited** — `scripts/generate-stars-css.ts` writes it from `server/keyframes.ts`'s `ANIMATIONS` data (see Architecture below); edit the data there and run `just generate-css`, don't edit this file directly, since `just check` regenerates it in `--check` mode and fails the build if the two have drifted. Changing an animation's duration still means updating the matching offset(s) in `client/animation-timeline.ts`'s `ANIMATION_TIMELINE` too — durations and stage timing are not derived from each other.
-  - **`client/css/responsive.css`** (`layer: responsive`, last) — the `prefers-reduced-motion`/`max-width`/`orientation` media queries, kept as one file rather than split into each component's own file since they already cross-cut `console-btn`/`dock-btn`/`footer`/`console-card` and reordering them into per-component files would obscure the "these are the overrides" mental model.
+- **`client/preview.ts`** — the preview dialog that runs before an upload. It has three steps: `source`, `crop`, and `edit`. `setStep()` owns the visible state of all three plus their navigation buttons. The source step accepts a file in three ways: a drag and drop on `#source-drop-zone`, a Ctrl-V paste into the dialog, or the `#source-browse-btn` button. That button clicks the hidden `#file-upload` input. A touch-first device reaches none of the first two, so the `.upload-trigger` buttons skip the source step there and click the file input directly. The `isMobile` test needs two media queries together: a coarse primary pointer with no hover, and no fine pointer under `any-pointer`. The second query keeps a touchscreen laptop with a mouse on the desktop path. `client/export.ts` repeats this same test for its default orientation. The crop step uses [`cropperjs`](https://github.com/fengyuanchen/cropperjs) v2. That version is the rewrite with Web Components. `new Cropper(image, { container })` renders a tree of custom elements under `<cropper-canvas>`. It is not one widget. The code drives it through the instance API with the `$` prefix: `$ready`, `$center`, `$scale`, `getCropperSelection()`, `$change`, and `$toCanvas`. It does not use DOM attributes. The crop step sizes the image to `IMAGE_FIT_SCALE` (80%) of the crop zone on init. It calls `$center('contain').$scale(...)` for this. It then calls `$change()` on the selection at once. The new bounds match the rendered bounds of the image exactly. The code reads both with `getBoundingClientRect()`, on the image and on the canvas. The `initial-coverage` option of cropperjs sizes the selection against the *canvas*, not the image. Without this correction, a full-coverage selection would also take the empty letterbox margin. That margin becomes extra transparent space. This happens whenever the aspect ratio of the image differs from the aspect ratio of the crop zone. `(getCropperSelection() as CropperSelection).$toCanvas()` renders the crop result into `#edit-canvas`. It then hands off to `initTransparencyTools()` for the second step. See below. The upload always sends `cropped.png` through `fetch('/upload', ...)`. This is true even when the user skips the transparency tools. The server accepts PNG only. See `server.ts` above. `fetch` follows the 303 redirect itself. The code therefore reads the result from the final `res.url` and `res.status`. It does not read the redirect header. A path in the shape of a hash means success. The dialog then closes. The `onUploaded(hash)` callback then runs. The page does not navigate. Three cases mean failure: a bare `/` path with an `error` query parameter, a status of 500 or more, and a rejected `fetch` from a network failure. Each case closes the dialog. Each case then shows a message for that reason, through `#upload-error`. That element is a toast. The user can dismiss it. It also times out by itself. See `UPLOAD_ERROR_MESSAGES`. The page does not reload. The failure is never silent.
 
-  All files use native CSS nesting (`&:hover`, `&.hide`) — Bun's bundler (Lightning CSS) supports this directly, no preprocessor needed. Was originally one LESS file; converted to plain CSS since Bun's bundler doesn't support LESS and the only genuinely LESS-specific features were a few `@variable`-based compile-time arithmetic values in the `init` keyframes, now inlined as literals.
+- **`client/transparency.ts`** — the optional second step of the dialog. It offers two tools. The erase tool drags a brush. It draws with `globalCompositeOperation: 'destination-out'`. The color-pick tool takes one click on a pixel. It then clears every pixel within a tolerance. The tolerance is a Euclidean distance in RGB space. That tool works through `ImageData`. Both tools share one stack of undo and redo steps. Each step is an `ImageData` snapshot. `MAX_HISTORY` caps the stack. The code takes one snapshot per `pointerdown` event. A whole drag is therefore one undo step. It is not one step per brush mark. `initTransparencyTools()` returns a `reset()` function. `preview.ts` calls it for each new crop in `#edit-canvas`. The call clears the tool state and the history.
 
-- **`client/public/img/doge.png`** — served through a manual route rather than the HTML bundler, since it's referenced dynamically (see `script.ts` above). `client/public/` also holds `favicon.png`/`preview.jpg` (same manual-route reasoning), `videos/background.vtt` (manual route too, for the `<track>`-isn't-bundled reason described under `index.html` above), and `videos/background.mp4` (bundler-processed, see `index.html` above).
+- **`client/export.ts`** — the client half of the export feature. `initExport()` wires `#export-btn` in the dock. That button opens `#export-options-dialog`. The dialog holds four option rows: orientation, resolution, frame rate, and format. Each row is a group of buttons with a `data-value` attribute. `selectOption()` and `getSelected()` read and write the `aria-pressed` state of a group. Both are generic over the value type of the row, so a caller gets a typed value back with no `as` cast. The default orientation follows the device type, not the current viewport: portrait on mobile, landscape elsewhere. It uses the same `isMobile` test as `client/preview.ts`. It is a deliberate product choice. The user can still change it.
+  - `applyGifCap()` runs after every option click. It disables each resolution button and frame rate button above the GIF cap while GIF is selected. It also moves the current selection down through `clampForGif()`, the same function the server enforces with. The two sides therefore cannot disagree on the cap. `updateGifWarning()` shows a real size estimate in `#gif-size-warning`. `GIF_SIZE_ESTIMATE_MB` holds measured sizes for the four allowed pairs, from 17MB up to 42MB. The orientation does not change the pixel count, so one entry covers both. A warning with a real number replaces a silent server-side downscale.
+  - `runExport()` disables the button, opens `#export-progress-dialog`, and polls `/export-status` every 200 ms. The progress label reads "Finalizing…" between `FRAME_PROGRESS_CAP` and 100. A frozen percentage would read as a broken export. A successful response becomes a `Blob`. An `<a download>` element with an object URL starts the save. A failed response shows a message keyed by HTTP status, through the same `#upload-error` toast that `preview.ts` uses. That element is a generic dismissible message despite its id.
 
-- **`uploads/`** — runtime-written, gitignored, lives at the project root (a sibling of `server/`/`client/`, not nested inside either — it's runtime data, not source). In Docker this is a bind-mounted volume (`${UPLOADS_DIR}` on the host, defaulting to `/tmp/shooting-stars-uploads` per `docker-compose.yml` — point it at a real persistent path for production) so uploads survive container recreation, shared by the `bun`/`bun-dev` and `cleanup` services.
+- **`client/export-options.ts`** — the export option types, constants, and logic. It holds `Orientation`, `Resolution`, `FrameRate`, `ExportFormat`, `RESOLUTION_ORDER`, `GIF_MAX_RESOLUTION`, `GIF_MAX_FPS`, `clampForGif()`, and `FRAME_PROGRESS_CAP`. `server/export.ts` imports this file across the client boundary, the same way it imports `client/animation-timeline.ts`. It then re-exports the whole file with `export *`, so the `from "./export"` imports in `server.ts` and `export-worker.ts` need no change. This file has no dependency at all. It touches no DOM. It calls no Bun API and no Node API. It is therefore safe in the browser bundle and under Bun. One copy here is what stops the GIF caps and the clamp logic from drifting between the two sides. 720p is the highest tier because `background.mp4` is itself 1280x720. A 1080p export would only upscale the background.
 
-- **`scripts/generate-stars-css.ts`** — generates `client/css/stars.css` from `server/keyframes.ts`'s `ANIMATIONS` (see above); run via `bun run generate:css`/`just generate-css` to write the file, or `bun run generate:css` with `--check` (wired as the `verify:css` script, folded into `bun run check`/`just check`) to compare the generated text against what's on disk and exit non-zero without writing — this is what actually enforces that the two files can't silently drift apart. Byte-identical output isn't the goal (Biome reformats the file anyway via `just format`); behavioral equivalence is — e.g. it always emits the two-argument `scale(x, y)` form even where `stars.css` was originally hand-authored with `scale(n)` or `scaleX(n)`, since they're computationally identical. Needs `./scripts` bind-mounted into the `bun-dev` service in `docker-compose.yml` (added alongside `server`/`client`) since `just check`/`just generate-css` both run inside that container.
+- **`client/volume.ts`** — the volume control in the `#quick-actions` dock. `initVolumeControl()` reads the `<video>` element through `getVideoElement()`, exported by `client/animation.ts`. No second `document.getElementById("video")` call exists. The slider starts from the value that `animation.ts` already set (`video.volume = 0.05`), rather than a second default that could drift. `#volume-btn` opens a small popover, `#volume-menu`. An outside click closes it. The Escape key closes it too, from any focused element inside. `isMuted()` treats a volume of 0 and the `.muted` flag as the same state, because both play silently. A drag on the slider always unmutes, which matches a native media player.
 
-- **`scripts/clean_old_uploads.sh`** + **`scripts/Dockerfile`** — the upload-retention job, now containerized instead of relying on host cron. The script wraps `find "$PATH_TO_UPLOADS" -type f -ctime "+$UPLOAD_RETENTION_DAYS" -delete -print`, counting the printed lines to log a timestamped `deleted N file(s)...` summary each run (visible via `docker logs`/`docker compose logs cleanup`); `PATH_TO_UPLOADS` defaults to `/uploads` (the cleanup service's fixed container-side mount point — not meant to be overridden via `.env`, unlike `UPLOADS_DIR` which controls the host side of that same mount), and `UPLOAD_RETENTION_DAYS` (default `30`) is read directly under the same name it has in `.env`, no renaming layer anywhere in the chain. `-type f` also means `find` never targets the `/uploads` mount point directory itself, even if every upload ages out at once. The `cleanup` service picks up `.env` the same way `bun`/`bun-dev` do, via `env_file:`, rather than cherry-picking individual vars into an `environment:` block. `scripts/Dockerfile` is a tiny `alpine:3` + `findutils` image (alpine's own `find` is busybox's and doesn't support `-ctime`) whose entrypoint is a `while true; sleep 1d` loop around the script — a deliberate shortcut over a real `crond` entry, since there's exactly one daily job; swap to `crond` if a real schedule (specific time, multiple jobs) is ever needed. Wired into `docker-compose.yml` as the `cleanup` service (default profile, runs alongside `bun` in production; `restart: unless-stopped`).
+- **`client/style.css`** — a thin manifest. It is not a stylesheet in its own right. It declares the cascade layer order: `@layer base, components, dialog, stars, responsive;`. It then imports each domain file below from `client/css/`. `index.html` still links this one file as `./style.css`. The bundler of Bun (Lightning CSS) resolves the imports. It inlines them into one bundled stylesheet at serve time. Tests confirmed this in the development mode output. It is not an assumption. The layer order is the important part here. A rule in a later layer beats a rule in an earlier layer. Selector specificity does not change that. Source order does not change that either. `css/responsive.css` is last. It can therefore override `css/buttons.css` and `css/landing.css` in the `components` layer. It never has to fight ID specificity against class specificity.
+  - **`client/css/base.css`** (`layer: base`) — the global page chrome. This chrome is present on every screen. It covers the `:root` theme variables, the `html` and `body` reset, `#starfield`, the `video#video` background element, `#pictures-container`, and the persistent `footer`.
+  - **`client/css/buttons.css`** (`layer: components`) — the shared button chrome. The landing screen uses it. Playback also uses it. It covers `.console-btn` with its `--primary` and `--secondary` variants, `#quick-actions`, `.dock-btn`, the hidden `#file-upload` input, and the focus ring trick of that input.
+  - **`client/css/landing.css`** (`layer: components`) — the idle-state user interface: `#landing`, `.console-card` with its contents, and `#upload-error`.
+  - **`client/css/dialog.css`** (`layer: dialog`) — all three `<dialog>` elements. It covers the upload preview dialog with its source step, crop step, and edit step. It also covers `#export-options-dialog` and `#export-progress-dialog`. Both reuse the transparent host and the blurred backdrop of `#preview-dialog`. Shared pieces are `.tool-picker`, `.option-row`, `.slider-control`, and `.preview-actions`. The two export dialogs are declared before the `& > .tagline` rule of the preview steps. This order satisfies the static specificity check of Biome. See Linting/formatting above.
+  - **`client/css/stars.css`** (`layer: stars`) — the shooting-stars animation itself. It expresses the animation as native CSS `@keyframes` rules, one set per stage. The stages are `init`, `spaceone`, `dolphins`, `spacetwo`, `microone`, and `microtwo`. Each stage has one keyframe variant per picture, for example `spacetwo_1` through `spacetwo_6`. Each variant has a different transform and a different timing. The images therefore do not move identically. **A script generates this file.** Do not edit it by hand. `scripts/generate-stars-css.ts` writes it from the `ANIMATIONS` data in `server/keyframes.ts`. Edit that data. Then run `just generate-css`. `just check` regenerates the file in `--check` mode. It fails the build when the two files have drifted apart. A change to an animation duration also needs a change to `ANIMATION_TIMELINE` in `client/animation-timeline.ts`. Update the matching offsets there by hand. The durations and the stage timings do not derive from each other.
+  - **`client/css/responsive.css`** (`layer: responsive`, last) — the media queries: `prefers-reduced-motion`, `max-width`, and `orientation`. It stays as one file. The queries already cross-cut `console-btn`, `dock-btn`, `footer`, and `console-card`. A split into per-component files would hide the "these are the overrides" model. Its largest block turns `#preview-dialog` fullscreen and opaque on a touch-first device. That block also hides `#starfield`, whose endless keyframes over a 7-layer radial gradient cost a mobile GPU a real repaint. It also overrides the browser default size cap on `dialog:modal`, which was the source of a scrollbar problem, and sizes `#edit-canvas` with `flex: 1` plus `object-fit: contain` so the bitmap keeps its aspect ratio inside a flexible box.
 
-- **`Dockerfile`** — based on `oven/bun:1` (Debian, not `-alpine` — see the file's own header comment: Bun has a libc-detection bug on Alpine that already broke `lightningcss` and would bite `@napi-rs/canvas` too), working directory `/app`. A `base` stage installs ffmpeg and copies the package manifest; `deps` (`bun install --frozen-lockfile`, full devDependencies included) feeds the `dev` target, since `bun-dev` is what `just check`/`just test` run against and those need `typescript`/`@biomejs/biome`; `deps-prod` (`bun install --frozen-lockfile --production`) is a sibling stage used only to supply `node_modules` to the final image, so devDependencies never ride along into prod. The final untargeted stage copies that `node_modules` plus `tsconfig.json`/`server/`/`client/` in and runs `bun server/server.ts` with `NODE_ENV=production` (bundling/minification happens lazily at runtime, no build stage or `dist/` artifact needed).
+  All of these files use native CSS nesting, such as `&:hover` and `&.hide`. The bundler of Bun (Lightning CSS) supports this directly. The project needs no preprocessor. The styles were one LESS file at the start. The project converted them to plain CSS. The bundler of Bun does not support LESS. The only true LESS features in use were a few compile-time arithmetic values in the `init` keyframes. Those values used `@variable` names. They are now literal values.
 
-- **`docker-compose.yml`** — three services: `bun` (default profile, production), `bun-dev` (profile `dev`, builds the `dev` Dockerfile target, bind-mounts `server/`/`client/`/`tsconfig.json`/`biome.json`/`package.json`/`.gitignore`/`tests/` for live editing — `just check`/`just format`/`just test` also run as one-off `docker compose run`s against this same service, so they always check/fix/test the current working tree rather than whatever was last baked into an image), and `cleanup` (default profile, builds `scripts/`, runs the upload-retention job). `bun`/`bun-dev`'s port mapping is `"${APP_PORT:-9595}:9595"` — only the host side is configurable via `.env`; the container side is always `9595`, matching `server.ts`'s hardcoded port. `UPLOADS_DIR`'s bind-mount path is likewise a `${VAR:-default}` interpolation rather than hardcoded.
+- **`client/public/img/doge.png`** — a manual route serves this file, not the HTML bundler. The code names it dynamically. See `script.ts` above. `client/public/` also holds `favicon.png` and `preview.jpg`. Manual routes serve them for the same reason. It holds `videos/background.vtt` too. A manual route serves that file because the bundler ignores `<track>`. See `index.html` above. It also holds `videos/background.mp4`. The bundler does process that file. See `index.html` above.
 
-- **`tests/server.test.ts`** — `bun:test` against the real `server/server.ts`, imported directly (its port is fixed at `9595`, but each `bun test` run happens in its own throwaway container via `docker compose run`, which doesn't publish ports, so it never collides with an already-running `bun`/`bun-dev` service). Covers: `/` loads, a PNG upload redirects to a `/<hash>` URL that itself loads, a non-image and a non-PNG-image upload are both rejected back to `/`, a never-uploaded hash 404s under `/uploads/*`, a legacy (pre-PNG-restriction) non-PNG upload still resolves/serves by extension, security headers are present on `/uploads/*` responses, `/img/*` serves the default doge image, and `/videos/*` serves the background video's captions file. Cleans up any file it writes to `uploads/` in `afterAll`.
+- **`uploads/`** — the runtime file store. Git ignores it. It sits at the project root. It is a sibling of `server/` and `client/`. It is not inside either one. It holds runtime data, not source. Docker mounts it as a bind volume. The host path comes from `${UPLOADS_DIR}`. `docker-compose.yml` defaults that to `/tmp/shooting-stars-uploads`. Point it at a real persistent path for production. The mount keeps the uploads across a container recreation. The `bun`, `bun-dev`, and `cleanup` services share it.
+
+- **`scripts/generate-stars-css.ts`** — generates `client/css/stars.css`. It reads the `ANIMATIONS` data in `server/keyframes.ts`. See above. Run `bun run generate:css` or `just generate-css` to write the file. Run `bun run generate:css` with `--check` to compare instead. That mode compares the generated text against the file on disk. It exits non-zero. It writes nothing. The `verify:css` script wraps that mode. `bun run check` and `just check` both run it. This check is what stops the two files from drifting apart. Byte-identical output is not the goal. `just format` reformats the file through Biome anyway. Equal behavior is the goal. For example, the generator always emits the two-argument `scale(x, y)` form. The original hand-written `stars.css` used `scale(n)` or `scaleX(n)` in places. Both forms compute the same result. `docker-compose.yml` must bind-mount `./scripts` into the `bun-dev` service, next to `server` and `client`. `just check` and `just generate-css` both run in that container.
+
+- **`scripts/clean_old_uploads.sh`** + **`scripts/Dockerfile`** — the upload retention job. It runs in a container. It no longer needs host cron. The script wraps one command: `find "$PATH_TO_UPLOADS" -type f -ctime "+$UPLOAD_RETENTION_DAYS" -delete -print`. It counts the printed lines. It then logs a timestamped `deleted N file(s)...` summary for each run. `docker logs` shows that summary. `docker compose logs cleanup` shows it too. `PATH_TO_UPLOADS` defaults to `/uploads`. That path is the fixed mount point inside the cleanup container. Do not override it through `.env`. `UPLOADS_DIR` controls the host side of the same mount. `UPLOAD_RETENTION_DAYS` defaults to `30`. The script reads it under the same name that `.env` uses. No layer in the chain renames it. `-type f` also keeps `find` off the `/uploads` mount point directory itself. This holds true even when every upload ages out at once. The `cleanup` service reads `.env` through `env_file:`, as `bun` and `bun-dev` do. It does not copy single variables into an `environment:` block. `scripts/Dockerfile` builds a small image from `alpine:3` plus `findutils`. The `find` command of alpine comes from busybox. That version does not support `-ctime`. The entrypoint is a `while true; sleep 1d` loop around the script. This is a deliberate shortcut over a real `crond` entry. The project has exactly one daily job. Change to `crond` when a real schedule becomes necessary, for example a specific time or several jobs. `docker-compose.yml` holds this as the `cleanup` service. It uses the default profile. It runs next to `bun` in production. Its restart policy is `unless-stopped`.
+
+- **`Dockerfile`** — builds on `oven/bun:1`. That image is Debian, not `-alpine`. The header comment of the file gives the reason. Bun has a libc detection fault on Alpine. That fault already broke `lightningcss`. It would break `@napi-rs/canvas` too. The working directory is `/app`. The `base` stage installs ffmpeg. It also copies the package manifest. The `deps` stage runs `bun install --frozen-lockfile`. It keeps the full devDependencies. It feeds the `dev` target. `just check` and `just test` run against `bun-dev`. Those commands need `typescript` and `@biomejs/biome`. The `deps-prod` stage runs `bun install --frozen-lockfile --production`. It is a sibling stage. It supplies `node_modules` to the final image only. The devDependencies therefore never reach production. The final stage has no target name. It copies that `node_modules` in. It also copies `tsconfig.json`, `server/`, and `client/`. It runs `bun server/server.ts` with `NODE_ENV=production`. Bundling and minification happen at runtime, on demand. The project needs no build stage. It needs no `dist/` artifact.
+
+- **`docker-compose.yml`** — holds three services. `bun` runs production. It uses the default profile. Its healthcheck runs `bun -e` with a `fetch()` call. The `oven/bun:1` image carries no `wget` and no `curl`, unlike the old Alpine image, and one healthcheck does not justify another package. `bun-dev` uses the `dev` profile. It builds the `dev` target of the Dockerfile. It bind-mounts `server/`, `client/`, `scripts/`, `tsconfig.json`, `biome.json`, `package.json`, `.gitignore`, and `tests/` for live editing. `just check`, `just format`, and `just test` also run against this service, each as a one-off `docker compose run`. They therefore always read the current working tree. They never read the last image build. `cleanup` uses the default profile. It builds `scripts/`. It runs the upload retention job. The port map of `bun` and `bun-dev` is `"${APP_PORT:-9595}:9595"`. Only the host side takes a value from `.env`. The container side is always `9595`. That value matches the fixed port in `server.ts`. The bind mount path of `UPLOADS_DIR` is also a `${VAR:-default}` expansion, not a fixed value.
+
+- **`tests/server.test.ts`** — runs `bun:test` against the real `server/server.ts`. It imports the server directly. The port of the server is fixed at `9595`. Each `bun test` run happens in its own throwaway container, through `docker compose run`. That container publishes no ports. A test run therefore never collides with a running `bun` service or `bun-dev` service. The route tests cover these cases: `/` loads; a PNG upload redirects to a `/<hash>` URL that itself loads; the server rejects a non-image upload back to `/`; the server rejects a non-PNG image upload back to `/`; the server rejects a file that declares `image/png` but carries other bytes; a hash that nobody uploaded gives a 404 under `/uploads/*`; a legacy non-PNG upload from before the restriction still resolves by extension and still serves; the security headers are present on `/uploads/*` responses; `/img/*` serves the default doge image; `/videos/*` serves the captions file of the background video.
+  - The export tests run real end-to-end renders. They mock out neither `ffmpeg` nor the canvas, because the speed of a real render is the point of the feature. They cover MP4, WebM, GIF, a non-default resolution, the `doge` fallback filename, the hash-based filename, the 429 from a second concurrent export, and `/export-status` both idle and during a render. The GIF cap test asks for 720p at 60fps and expects a fast answer, which proves `clampForGif()` runs on the server. A test that needs a real hash uploads the true `doge.png` bytes through `uploadDoge()`, because an export decodes the file with `loadImage()` and a placeholder PNG fails there. `afterAll` removes every file that the tests write to `uploads/`.
+
+- **`tests/keyframes.test.ts`** — covers the pure animation arithmetic with no HTTP and no render. It tests `interpolate()` and `resolvePictureFrame()` from `server/keyframes.ts`, including the identity boundary, the mid-segment case, and the wrap around `durationMs`. It also tests the helpers that `server/export.ts` groups under `testInternals`: `travelScale`, `pictureBox`, `findStage`, `cssFilterString`, `renderFilterChain`, `renderFilterComplex`, and `buildFilterComplex`. Those helpers are pure and do no input or output. They are exported under one name so the real public API of the module stays separate.
+
+- **`tests/animation-timeline.test.ts`** — two guards on `client/animation-timeline.ts`. The first checks the offsets that `buildTimeline()` computes against the original hardcoded numbers. The second checks that every picture visible in a stage has a matching `ANIMATIONS` entry, through `pictureAnimationKey()`. The second one is what catches a rename or a renumbering that splits the CSS from the export data.
 
 ## Notes
 
-- The upload filter only checks MIME type (must be exactly `image/png`) and size (`MAX_UPLOAD_SIZE`), not file contents or extension.
-- The app always listens on `9595`; only the Docker host-side publish port (`APP_PORT` env var) can differ, and in the current compose setup is bound to localhost only.
-- Uploaded files older than `UPLOAD_RETENTION_DAYS` (default 30) are deleted daily by the `cleanup` compose service — see `scripts/` in Architecture above.
+- The upload filter runs three checks: the declared MIME type must be exactly `image/png`, the size must be under `MAX_UPLOAD_SIZE`, and the first 8 bytes must be the PNG magic number. It does not check the extension. It does not parse the rest of the file.
+- The application always listens on `9595`. Only the publish port on the host can differ. The `APP_PORT` variable sets it. The current Compose setup binds it to localhost only.
+- The `cleanup` service deletes old uploaded files each day. It deletes files older than `UPLOAD_RETENTION_DAYS`. The default is 30 days. See `scripts/` in Architecture above.
+- Only one export can run at a time. A second request gets a 429 status. The lock is a module-level flag in `server/server.ts`, so it does not survive a restart.
+- The animation timings live in three places that nothing derives from each other: `ANIMATION_TIMELINE` in `client/animation-timeline.ts`, the `durationMs` values in `server/keyframes.ts`, and the runtime of `videos/background.mp4`. Keep them in step by hand.
+
+## Writing style
+
+Write code comments, commit messages, project documentation files such as
+this one, and chat responses to the user in ASD-STE100 Simplified Technical
+English. Do not use this style for code, file paths, or identifiers. Follow
+these rules exactly:
+
+- Keep each sentence to 20 words or fewer.
+- Write one instruction or one fact per sentence. Do not join two facts with "and", "or", or a comma.
+- Use active voice. Name the actor. Do not write "the event can be lost"; write "focus loss can drop the event".
+- Use plain, common words. Do not use slang or informal words, for example "spam" or "wiggle".
+- Do not use contractions. Write "do not", not "don't".
+- Keep noun clusters to 3 words or fewer. Add an article or a preposition to break up a longer string of nouns.
+- Do not just append a new sentence to an existing comment. Revise the whole comment. Check it against every rule above again. Cut it back to 2 to 3 lines.
+- The 2 to 3 line target applies to each comment. Keep the reason, not the history. State why the code is this way. Do not list every option that somebody rejected. Move a long explanation into this file instead, then point at it from the code.
+
+Example, before and after:
+
+```ts
+// Before: passive voice, one 33-word run-on sentence, informal word "wiggle".
+// The release event can be lost, for example when the window loses focus
+// mid-drag. Recover here, or the card stays raised and stuck to the last
+// mouse position forever, with the button no longer down.
+
+// After: two short active-voice sentences, plain words.
+// A focus change can drop the release event. This check ends the drag
+// when the button is already up.
+```
+
+Check every new or changed comment against these rules. Do this at the same
+time as `just check`. Do this before you call a code change done.
 
 ## Contributing
 
-Commit messages **must** follow [Conventional Commits](https://www.conventionalcommits.org/)
-(`type(scope): subject`, e.g. `fix: correct upload hash length`) — this isn't
-just style. `.releaserc.json` runs `semantic-release` with the default
-`@semantic-release/commit-analyzer` (Angular preset) on every push to `main`
-via `.github/workflows/release.yaml`: it parses commit types to decide
-whether to cut a release and what version bump to apply (`fix:` → patch,
-`feat:` → minor, `BREAKING CHANGE:` footer or `!` → major, other types like
-`chore:`/`docs:`/`refactor:` → no release), then generates `CHANGELOG.md`
-entries from those same messages. A non-conventional commit message is
-silently ignored by the analyzer rather than erroring, so the practical
-failure mode is a change landing with no version bump/changelog entry, not
-a build break. Before opening a PR, run `just check`/`just test` locally
-(see Commands above) — CI (`.github/workflows/build.yml`) runs the same
-checks.
+Commit messages **must** follow
+[Conventional Commits](https://www.conventionalcommits.org/). The form is
+`type(scope): subject`, for example `fix: correct upload hash length`. This
+rule is not only style.
+
+`.releaserc.json` runs `semantic-release`.
+`.github/workflows/release.yaml` starts it on every push to `main`. It uses
+the default `@semantic-release/commit-analyzer` with the Angular preset. The
+analyzer parses the commit types. It then decides whether to cut a release.
+It also decides the version step:
+
+- `fix:` gives a patch release.
+- `feat:` gives a minor release.
+- A `BREAKING CHANGE:` footer gives a major release. A `!` marker does the same.
+- Other types, such as `chore:`, `docs:`, and `refactor:`, give no release.
+
+The analyzer then writes the `CHANGELOG.md` entries from those same messages.
+
+The analyzer ignores a commit message that does not follow the convention. It
+raises no error. The practical failure is therefore a silent one. The change
+lands with no version step and no changelog entry. The build does not break.
+
+Run `just check` and `just test` before you open a pull request. See Commands
+above. CI runs the same checks, through `.github/workflows/build.yml`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,34 @@
-# ---- base: package manifest + ffmpeg, shared by every stage below ----
-# Debian-based, not oven/bun:1-alpine like before the export feature (see
-# server/export.ts): @napi-rs/canvas ships prebuilt musl (Alpine) binaries in
-# principle, but Bun has its own libc-detection bug on Alpine images that has
-# already bitten a different native dependency in this repo (lightningcss) —
-# switching base image sidesteps it rather than debugging musl detection.
+# ---- base: the package manifest and ffmpeg, shared by every stage below ----
+# Debian, not oven/bun:1-alpine as before the export feature. Bun has a libc
+# detection fault on Alpine that already broke lightningcss here, and would
+# reach @napi-rs/canvas too. A different base image avoids it.
 FROM oven/bun:1 AS base
 WORKDIR /app
 COPY package.json bun.lock /app/
-# ffmpeg composites the export's rendered frames over background.mp4 and
-# encodes the result (see server/export.ts) — needed in dev too, since
-# bun-dev is what `just test` and manual export testing run against.
+# ffmpeg composites the rendered export frames over background.mp4 and
+# encodes the result (see server/export.ts). The dev image needs it too:
+# `just test` runs against bun-dev.
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-# ---- deps: full install (incl. devDependencies), used by dev only ----
-# `just check`/`just test` run typecheck/lint against bun-dev, so that image
-# needs typescript/@biomejs/biome — the prod image below does not.
+# ---- deps: the full install with devDependencies, for dev only ----
+# `just check` and `just test` run against bun-dev. That image therefore needs
+# typescript and @biomejs/biome. The production image below does not.
 FROM base AS deps
 RUN bun install --frozen-lockfile
 
-# ---- dev: live HMR via `bun --hot`, source is bind-mounted at runtime ----
+# ---- dev: live HMR through `bun --hot`. Compose bind-mounts the source. ----
 FROM deps AS dev
 CMD ["bun", "--hot", "server/server.ts"]
 
-# ---- deps-prod: runtime-only install, keeps devDependencies out of prod image ----
+# ---- deps-prod: a runtime-only install. It keeps devDependencies out. ----
 FROM base AS deps-prod
 RUN bun install --frozen-lockfile --production
 
-# ---- prod: source baked in, Bun bundles/minifies/caches assets lazily at runtime ----
-# NODE_ENV=production is the one signal Bun.serve checks to switch its HTML-import
-# bundler from dev mode (unminified, /_bun/ paths) to production mode (minified,
-# cached, hashed filenames) — genuinely load-bearing, not leftover branching.
+# ---- prod: the source is baked in. Bun bundles the assets at runtime. ----
+# NODE_ENV=production is the one signal Bun.serve reads to switch its
+# HTML-import bundler to minified, cached, hashed output. Load-bearing, not
+# leftover branching.
 FROM base
 ENV NODE_ENV=production
 COPY --from=deps-prod /app/node_modules /app/node_modules

--- a/client/animation-timeline.ts
+++ b/client/animation-timeline.ts
@@ -1,23 +1,17 @@
-// Pure data, no DOM access — split out of animation.ts so server/export.ts
-// can import the choreography table without pulling in animation.ts's
-// top-level `document.getElementById(...)` calls (which throw outside a
-// browser, e.g. under `bun test`).
+// Pure data, with no DOM access. The split from animation.ts lets
+// server/export.ts import the choreography table alone: the top-level
+// `document.getElementById(...)` calls there throw under `bun test`.
 
 export type AnimationStage = {
 	class: string;
 	pictures: string[];
 };
 
-// Authored as relative gaps (ms since the previous stage started) rather
-// than absolute cumulative offsets, so retiming one stage doesn't require
-// hand-recomputing every later stage's key — ANIMATION_TIMELINE below is
-// derived from this at module load. gapMs has NO derived relationship to
-// server/keyframes.ts's per-animation durationMs or to stars.css's keyframe
-// durations (see CLAUDE.md): stages are staggered entrances, not
-// back-to-back full loops, so a stage's own animation duration isn't the
-// same thing as its gap to the next stage. These are still independently,
-// manually chosen and must stay in sync with stars.css and
-// background.mp4's runtime by hand.
+// Relative gaps, in milliseconds since the previous stage started. Absolute
+// offsets would force a recount of every later key after one retiming.
+// gapMs derives from nothing else. A stage is a staggered entrance, not a
+// full loop, so its animation duration is not its gap to the next stage.
+// Keep these in step with stars.css and background.mp4 by hand.
 type StageDef = AnimationStage & {
 	gapMs: number;
 };
@@ -47,20 +41,15 @@ function buildTimeline(defs: StageDef[]): Record<number, AnimationStage> {
 	return table;
 }
 
-// the choreography table: millisecond offsets (from startAnimation()) to
-// which stage class applies and which pictN ids are visible at that point.
-// Shared with the server-side export renderer (server/export.ts) so both
-// drive the exact same timeline instead of keeping separate copies — this
-// must still stay in sync with stars.css's keyframe durations by hand (see
-// CLAUDE.md), but at least the timeline itself now has one source of truth.
+// The choreography table: a millisecond offset from startAnimation() to the
+// active stage class and its visible pictN ids. server/export.ts shares it,
+// so both sides drive the same timeline.
 export const ANIMATION_TIMELINE: Record<number, AnimationStage> =
 	buildTimeline(STAGE_DEFS);
 
-// the `${stageClass}_${pictureIndex + 1}` convention used to key both
-// ANIMATIONS (server/keyframes.ts) and stars.css's class selectors —
-// centralized here (rather than duplicated in client/animation.ts and
-// server/export.ts) so a typo/renumbering in one call site can't silently
-// diverge from the other.
+// The `${stageClass}_${pictureIndex + 1}` convention that keys both
+// ANIMATIONS and the stars.css class selectors. One function, so a typo or a
+// renumbering cannot make two call sites disagree.
 export function pictureAnimationKey(
 	stageClass: string,
 	pictureIndex: number,

--- a/client/animation.ts
+++ b/client/animation.ts
@@ -1,5 +1,5 @@
-// the shooting-stars choreography engine: launch prompt + the timed
-// picture/video sequence itself
+// The shooting-stars choreography engine. It holds the launch prompt. It
+// also holds the timed picture sequence and video sequence.
 
 import { ANIMATION_TIMELINE, pictureAnimationKey } from "./animation-timeline";
 
@@ -8,9 +8,9 @@ video.volume = 0.05;
 video.addEventListener("ended", restartAnimation, false);
 
 /**
- * Lets other modules (currently just volume.ts) read/mutate playback
- * properties like .volume/.muted without each grabbing their own
- * `document.getElementById("video")` reference
+ * Lets other modules read and change playback properties such as .volume,
+ * without each one taking its own `getElementById("video")` reference.
+ * Only volume.ts uses it now.
  */
 export function getVideoElement(): HTMLVideoElement {
 	return video;
@@ -22,33 +22,30 @@ const tapToPlay = document.getElementById("tap-to-play") as HTMLElement;
 const tapToPlayText =
 	'<span class="spark">✦</span> Press to fly <span class="spark">✦</span>';
 
-// pending setTimeout ids for the current run's picture choreography, so a
-// restart (e.g. uploading a new image mid-flight) can cancel them instead
-// of leaving them to fire later and stomp on the new run's classes
+// The pending setTimeout ids of the choreography of this run. A restart
+// cancels them, so a stale timeout cannot overwrite the new run's classes.
 let animationTimeouts: ReturnType<typeof setTimeout>[] = [];
 
-// how long to wait for the video's `playing` event before starting the
-// picture choreography anyway — covers stalled buffering, a decode error,
-// or a play() rejection, any of which would otherwise never fire `playing`
-// and leave the choreography stuck waiting forever
+// How long to wait for the `playing` event before starting anyway. Stalled
+// buffering, a decode error, or a rejected play() call each hold it back
+// forever.
 const PLAYING_FALLBACK_MS = 1000;
 
-// the current run's pending "start the choreography" trigger (either the
-// video's `playing` event or the fallback timeout above, whichever fires
-// first) — tracked so a restart before either has fired can cancel them,
-// instead of leaving a stale one to double-schedule alongside the new run's
+// The pending start trigger of this run: the `playing` event or the fallback
+// timeout above, whichever comes first. Tracked so a restart can cancel both
+// before a stale one schedules a second choreography.
 let pendingTimelineStart: (() => void) | null = null;
 let pendingTimelineFallback: ReturnType<typeof setTimeout> | null = null;
 
-// showLaunchPrompt() re-runs on every restart (video 'ended', or a fresh
-// upload) — this guards against re-attaching the click/touchend listeners
-// each time, which would otherwise fire startAnimation multiple times per
-// tap. Can't just attach them once unconditionally at module load instead:
-// they're deliberately gated behind the video being ready (see below).
+// showLaunchPrompt() runs again on every restart, so this flag stops a
+// second listener attachment that would fire startAnimation twice per tap.
+// A single attachment at module load cannot work: the listeners wait on the
+// ready state of the video.
 let launchListenersAttached = false;
 
 /**
- * Restart the event (automatic if desktop, manually if mobile)
+ * Restarts the event. A desktop browser does this automatically. A mobile
+ * browser needs a tap from the user.
  */
 export function restartAnimation() {
 	video.style.display = "none";
@@ -56,8 +53,8 @@ export function restartAnimation() {
 }
 
 /**
- * Don't allow launching until the video is actually loaded, so the
- * animation can never run ahead of a video that isn't ready yet
+ * Blocks the launch until the video loads. The animation can therefore never
+ * run ahead of a video that is not ready.
  */
 function showLaunchPrompt() {
 	landing.style.display = "flex";
@@ -65,13 +62,12 @@ function showLaunchPrompt() {
 	starfield.classList.remove("fade-out");
 	if (video.readyState >= video.HAVE_CURRENT_DATA) {
 		tapToPlay.innerHTML = `<p>${tapToPlayText}</p>`;
-		// scoped to the prompt itself, not the whole page — only clicking/
-		// tapping this specific element launches the animation (being a
-		// real <button> also gets Enter/Space handling for free)
+		// Scoped to the prompt, not the page: only this element launches
+		// the animation. It is a real <button>, so Enter and Space work.
 		if (!launchListenersAttached) {
 			tapToPlay.addEventListener("touchend", (event) => {
-				// without this, the synthetic click that follows a touch
-				// tap would call startAnimation() a second time
+				// A touch tap also sends a synthetic click event. This
+				// call stops a second startAnimation() call.
 				event.preventDefault();
 				startAnimation();
 			});
@@ -86,25 +82,24 @@ function showLaunchPrompt() {
 	}
 }
 
-// pictures classes
+// The picture classes.
 const pictures = ["pict1", "pict2", "pict3", "pict4", "pict5", "pict6"];
 
 /**
- * Start the shooting stars animation — always (re)starts cleanly, so
- * calling it while a run is already ongoing (e.g. uploading a new image
- * mid-flight) restarts from "init" with the new image instead of just
- * swapping the picture src underneath whatever's currently flying.
+ * Starts the shooting stars animation, always cleanly. A call during a run
+ * restarts from "init" with the new image, rather than swapping the source
+ * under whatever is currently flying.
  */
 export function startAnimation() {
-	// cancel any still-pending choreography from a previous run so it can't
-	// fire later and stomp on this run's classes
+	// Cancels the pending choreography of an earlier run. Those timeouts
+	// would otherwise fire later and overwrite the classes of this run.
 	animationTimeouts.forEach((id) => {
 		clearTimeout(id);
 	});
 	animationTimeouts = [];
 
-	// cancel any still-pending choreography trigger from a previous run, so
-	// it can't fire later and double-schedule alongside this run's
+	// Cancels the pending start trigger of an earlier run. It would
+	// otherwise schedule a second choreography next to this one.
 	if (pendingTimelineStart) {
 		video.removeEventListener("playing", pendingTimelineStart);
 	}
@@ -112,8 +107,8 @@ export function startAnimation() {
 		clearTimeout(pendingTimelineFallback);
 	}
 
-	// fades out rather than vanishing instantly, so the console visibly
-	// hands off to the image that flies in during the "init" stage below
+	// Fades out instead of disappearing at once. The console therefore
+	// hands off visibly to the image of the "init" stage below.
 	landing.classList.add("fade-out");
 	starfield.classList.add("fade-out");
 	video.style.display = "block";
@@ -129,22 +124,19 @@ export function startAnimation() {
 	};
 	pendingTimelineStart = startTimelineOnce;
 
-	// don't schedule the picture choreography until the video has actually
-	// started rendering frames — on mobile, play()-call-to-first-frame
-	// latency is high enough that scheduling immediately (as before) makes
-	// the pictures visibly get ahead of the video. The fallback timeout
-	// covers the case where `playing` never fires at all (see
-	// PLAYING_FALLBACK_MS above).
+	// Waits for the first rendered frame before scheduling the choreography.
+	// A mobile browser is slow between play() and that frame, so an immediate
+	// schedule puts the pictures visibly ahead of the video.
 	video.addEventListener("playing", startTimelineOnce, { once: true });
 	pendingTimelineFallback = setTimeout(startTimelineOnce, PLAYING_FALLBACK_MS);
 
-	// play the background video from the start, even if a previous run
-	// left it mid-playback
+	// Plays the background video from the start. An earlier run can leave
+	// it part way through.
 	video.currentTime = 0;
 	video.play().catch(() => {
-		// autoplay blocked or playback otherwise failed to start — the
-		// fallback timeout above still kicks off the choreography so it
-		// isn't left stuck waiting for a video that will never play
+		// The browser blocked autoplay, or playback failed to start. The
+		// fallback timeout above still starts the choreography. It
+		// therefore never waits on a video that will not play.
 	});
 }
 

--- a/client/css/base.css
+++ b/client/css/base.css
@@ -23,10 +23,9 @@
 		background-color: black;
 	}
 
-	/* CSS-only starfield, sits between the video (z-index -100) and everything
-       else — visible behind the idle console, faded out in sync with #landing
-       once the animation launches (see script.ts) since the video covers the
-       screen from that point on anyway */
+	/* A starfield in pure CSS, between the video (z-index -100) and
+       everything else. It fades out with #landing at launch, since the video
+       covers the screen from then on. */
 	#starfield {
 		position: fixed;
 		inset: 0;
@@ -63,9 +62,9 @@
 			star-twinkle 3s ease-in-out infinite alternate;
 		transition: opacity 0.6s ease;
 
-		/* animation: none is required here — the twinkle/drift keyframes keep
-           driving opacity forever, which otherwise wins over this rule's own
-           opacity: 0 every other frame instead of actually fading out */
+		/* `animation: none` is required: the twinkle and drift keyframes
+           drive opacity forever and otherwise beat the `opacity: 0` here on
+           every other frame, so the element never fades out. */
 		&.fade-out {
 			opacity: 0;
 			animation: none;
@@ -108,22 +107,21 @@
 		left: 0;
 		width: 100%;
 		height: 100%;
-		/* purely decorative, never interactive — without this it sits on top
-           of (and blocks clicks/hover on) #tap-to-play in the stacking order,
-           since it comes later in the DOM and neither has a z-index */
+		/* Decoration only, never interactive. Without this it sits above
+           #tap-to-play and blocks clicks on it: it comes later in the DOM
+           and neither element carries a z-index. */
 		pointer-events: none;
-		/* keyframe translate()/scale() distances below are tuned in px for
-           desktop widths; this scales the whole rendered transform down
-           proportionally on narrow viewports so travel stays on-screen and
-           doesn't read as faster than on desktop */
+		/* The keyframe translate() and scale() distances below are tuned in
+           px for desktop widths. This scales the whole rendered transform
+           down on a narrow viewport, so travel stays on screen and does not
+           read as faster. */
 		--travel-scale: clamp(0.25, calc(100vw / 1400px), 1);
 
 		img {
 			position: absolute;
-			/* box grown by the inverse of --travel-scale so the `scale`
-               below cancels it out at rest — the image stays the same
-               fraction of the viewport as on desktop, only the travel
-               distance actually shrinks */
+			/* The box grows by the inverse of --travel-scale, so the `scale`
+               below cancels it at rest. The image keeps its share of the
+               viewport; only the travel distance shrinks. */
 			max-width: calc(30% / var(--travel-scale));
 			max-height: calc(30% / var(--travel-scale));
 			top: 0;

--- a/client/css/buttons.css
+++ b/client/css/buttons.css
@@ -1,6 +1,6 @@
 @layer components {
-	/* shared chrome for both landing CTAs (launch + upload) — same size/shape
-       so neither reads as the "secondary, corner" option anymore */
+	/* Shared chrome for both landing buttons, launch and upload. Same size
+       and shape, so neither reads as the secondary corner option. */
 	.console-btn {
 		display: inline-flex;
 		align-items: center;
@@ -51,15 +51,15 @@
 			filter: brightness(0.95);
 		}
 
-		/* no lift here (unlike :hover/:active) — keyboard focus shouldn't
-           shift the button's position, just call it out with the outline */
+		/* No lift here, unlike :hover and :active. Keyboard focus must not
+           move the button; the outline alone marks it. */
 		&:focus-visible {
 			outline: 2px solid var(--color-cyan);
 			outline-offset: 4px;
 		}
 	}
 
-	/* launch — the hero action, magenta + a slow glow pulse */
+	/* Launch, the main action. It uses magenta and a slow glow pulse. */
 	.console-btn--primary {
 		border-color: rgba(var(--color-magenta-rgb), 0.6);
 		box-shadow:
@@ -67,8 +67,8 @@
 			0 0 24px rgba(var(--color-magenta-rgb), 0.18);
 		animation: pulse-glow 2.4s ease-in-out infinite;
 
-		/* the sparkles either side of the text twinkle independently, offset
-           so they don't pulse in sync */
+		/* The two sparkles beside the text twinkle on their own. An offset
+           keeps them out of step with each other. */
 		.spark {
 			display: inline-block;
 			animation: twinkle 2.4s ease-in-out infinite;
@@ -78,17 +78,16 @@
 			}
 		}
 
-		/* pausing the glow pulse here (rather than fighting it every frame)
-           lets these static box-shadow/transform values actually stick while
-           interacting */
+		/* Pauses the glow pulse rather than fighting it every frame, so
+           these fixed box-shadow and transform values hold while the user
+           interacts. */
 		&:hover,
 		&:active {
 			animation-play-state: paused;
 		}
 
-		/* gradient fill + void text is the "you're hovering this" signal on
-           top of the lift — .spark inherits `color` from here too, so the
-           sparkles flip to void along with the text */
+		/* Gradient fill plus void text is the hover signal, on top of the
+           lift. .spark inherits `color` here, so the sparkles follow. */
 		&:hover {
 			background: linear-gradient(
 				135deg,
@@ -103,8 +102,8 @@
 		}
 	}
 
-	/* upload — the secondary action, cyan, calmer (no infinite pulse) so the
-       two CTAs read as equally prominent without competing for attention */
+	/* Upload, the secondary action: cyan and calmer, with no infinite pulse,
+       so the two buttons read as equally prominent. */
 	.console-btn--secondary {
 		&:hover {
 			background: linear-gradient(
@@ -146,8 +145,8 @@
 		}
 	}
 
-	/* persistent controls — stays visible/reachable while the animation is
-       running, unlike #landing (see script.ts) */
+	/* The persistent controls: visible and reachable while the animation
+       runs, unlike #landing. See script.ts. */
 	#quick-actions {
 		position: fixed;
 		top: 20px;
@@ -211,9 +210,8 @@
 		}
 	}
 
-	/* the volume popover that opens from #volume-btn — export now opens a
-       full <dialog> (see client/css/dialog.css's #export-options-dialog)
-       instead of a popover like this one */
+	/* The volume popover, opened from #volume-btn. Export now uses a full
+       <dialog> instead. See #export-options-dialog in dialog.css. */
 	#volume-group {
 		position: relative;
 	}
@@ -267,11 +265,9 @@
 		cursor: pointer;
 	}
 
-	/* purely an internal control now — only ever clicked programmatically,
-       either by #source-browse-btn inside the preview dialog or, on mobile
-       (which skips straight past the source step), directly by the
-       .upload-trigger buttons — never labeled/focused directly (see
-       tabindex="-1" in index.html) */
+	/* An internal control: only code clicks it, from #source-browse-btn or,
+       on mobile, straight from a .upload-trigger button. It is never labeled
+       or focused. See tabindex="-1" in index.html. */
 	input#file-upload {
 		opacity: 0;
 		position: absolute;

--- a/client/css/dialog.css
+++ b/client/css/dialog.css
@@ -34,14 +34,10 @@
 		);
 	}
 
-	/* the export render progress dialog — a native <dialog> opened with
-	   showModal() (see client/export.ts), so the rest of the page becomes
-	   inert for free while a render is in flight, matching #preview-dialog's
-	   own backdrop treatment. Declared here (before #crop-step/#edit-step's
-	   own & > .tagline rule below) since Biome's static specificity check
-	   flags a lower-specificity selector for a related property defined
-	   after a higher-specificity one, even though the two never actually
-	   collide — see CLAUDE.md's Linting/formatting notes. */
+	/* The export progress dialog, a native <dialog> opened with showModal()
+	   from client/export.ts, so the rest of the page goes inert during a
+	   render. Declared before the `& > .tagline` rule below to satisfy the
+	   static specificity check of Biome. See CLAUDE.md. */
 	dialog#export-progress-dialog {
 		border: none;
 		padding: 0;
@@ -83,10 +79,8 @@
 		}
 	}
 
-	/* the pre-export options dialog — same transparent-host + blurred-backdrop
-       treatment as #preview-dialog/#export-progress-dialog above; declared
-       here for the same Biome-specificity-ordering reason noted on
-       #export-progress-dialog */
+	/* The export options dialog: same transparent host and blurred backdrop
+       as the two above, declared here for the same Biome ordering reason. */
 	dialog#export-options-dialog {
 		border: none;
 		padding: 0;
@@ -231,8 +225,8 @@
 		height: 70vh;
 		border: 1.5px solid rgba(var(--color-cyan-rgb), 0.35);
 
-		/* cropper-canvas has no default width/height beyond a 100px min-height,
-           so without this it renders far smaller than its container */
+		/* cropper-canvas has no default size beyond a 100px min-height, so
+           without this it renders far smaller than its container. */
 		cropper-canvas {
 			width: 100%;
 			height: 100%;
@@ -256,7 +250,7 @@
 		cursor: crosshair;
 		border: 1.5px solid rgba(var(--color-cyan-rgb), 0.5);
 
-		/* checkerboard so erased/picked-transparent areas are visible while editing */
+		/* A checkerboard, so transparent areas stay visible while editing. */
 		background-image:
 			linear-gradient(45deg, #444 25%, transparent 25%),
 			linear-gradient(-45deg, #444 25%, transparent 25%),
@@ -372,7 +366,7 @@
 			}
 		}
 
-		/* dismissive action: muted red border, fills solid red on hover */
+		/* The dismiss action: muted red border, solid red on hover. */
 		#preview-cancel,
 		#export-options-cancel {
 			border-color: rgba(122, 42, 42, 0.7);
@@ -385,7 +379,7 @@
 			}
 		}
 
-		/* secondary/step-back action: neutral grey, same treatment */
+		/* The step-back action: neutral grey, same treatment. */
 		#edit-back {
 			border-color: rgba(230, 230, 240, 0.3);
 
@@ -407,8 +401,8 @@
 			}
 		}
 
-		/* the final, primary action — same magenta glow-pulse language as
-           #tap-to-play, so it's unmistakably the one to press */
+		/* The final action, in the magenta glow-pulse language of
+           #tap-to-play, so it is unmistakably the one to press. */
 		#preview-confirm {
 			font-size: 15px;
 			padding: 14px 28px;
@@ -437,7 +431,7 @@
 		}
 	}
 
-	/* swaps the label for a spinner while the upload is in flight */
+	/* Replaces the label with a spinner during an upload. */
 	#preview-confirm.is-loading {
 		color: transparent;
 		position: relative;

--- a/client/css/landing.css
+++ b/client/css/landing.css
@@ -71,9 +71,9 @@
 		);
 	}
 
-	/* idle-state UI — title + tagline + both CTAs, faded out together as a
-       single unit once the animation launches (see #landing.fade-out and
-       script.ts's startAnimation/showLaunchPrompt) */
+	/* The idle-state UI: title, tagline, and both buttons, faded out together
+       as one unit at launch. See #landing.fade-out and startAnimation in
+       script.ts. */
 	#landing {
 		display: none;
 		position: fixed;
@@ -83,10 +83,9 @@
 		justify-content: center;
 		padding: 24px;
 		box-sizing: border-box;
-		/* the flex box spans the full viewport (inset: 0) but only
-           .console-card is actually visible — without this, the empty area
-           around the card (which overlaps the footer) would still swallow
-           clicks meant for whatever's underneath */
+		/* The flex box spans the viewport through `inset: 0`, but only
+           .console-card is visible. Without this, the empty area around the
+           card overlaps the footer and swallows its clicks. */
 		pointer-events: none;
 
 		transition: opacity 0.4s ease;
@@ -94,10 +93,9 @@
 		&.fade-out {
 			opacity: 0;
 
-			/* .console-card sets its own pointer-events: auto below, which an
-               ancestor's pointer-events alone can't override — without this
-               the invisible card still intercepts clicks/keyboard focus for
-               the whole animation run */
+			/* .console-card sets its own `pointer-events: auto` below, which
+               an ancestor cannot override. Without this the invisible card
+               keeps taking clicks for the whole animation. */
 			.console-card {
 				pointer-events: none;
 			}

--- a/client/css/responsive.css
+++ b/client/css/responsive.css
@@ -96,12 +96,10 @@
 			padding: 6px 10px;
 		}
 
-		/* the export options dialog sizes itself to its widest .option-row
-           (format, 3 buttons) — on a narrow viewport the dialog then gets
-           squeezed below that intrinsic width, so which rows wrap becomes a
-           per-row accident of how much text that row happens to hold. Force
-           every row to stack the same way instead, and cap the dialog's own
-           width so content can't push it into a horizontal scrollbar. */
+		/* The dialog takes the width of its widest .option-row. A narrow
+           viewport squeezes it below that, and each row then wraps on its
+           own text length. These rules stack every row the same way and cap
+           the dialog width, so content cannot force a scrollbar. */
 		dialog#export-options-dialog,
 		dialog#export-progress-dialog {
 			width: min(94vw, 360px);
@@ -126,27 +124,23 @@
 		}
 	}
 
-	/* touch-primary devices can't drag-and-drop or Ctrl-V paste (see
-       client/preview.ts's matching isMobile() check, which skips the
-       source step entirely on these), and the floating card's live
-       backdrop-filter/box-shadow are expensive to keep compositing over
-       the still-animating starfield/video underneath on a mobile GPU — so
-       here the dialog goes fullscreen and opaque instead of floating+blurred */
+	/* A touch-first device supports neither drag and drop nor Ctrl-V paste,
+       and the matching isMobile() check in client/preview.ts skips the source
+       step there. A live backdrop-filter over the animating starfield also
+       costs a mobile GPU a lot, so the dialog goes fullscreen and opaque. */
 	@media (hover: none) and (pointer: coarse) {
-		/* the starfield's continuous background-position/opacity keyframes
-           over a 7-layer radial-gradient are a real repaint cost on mobile
-           GPUs, running non-stop even on the idle landing screen — it's
-           pure decoration (not the video, which stays untouched), so
-           hiding it here just falls back to body's own black background */
+		/* Endless background-position and opacity keyframes over a 7-layer
+           radial gradient cost a mobile GPU a real repaint, even when idle.
+           It is decoration only, so hiding it falls back to the black
+           background of body. The video is untouched. */
 		#starfield {
 			display: none;
 		}
 
-		/* the UA default for dialog:modal caps it at ~100% minus its own
-           border/margin and sets overflow:auto — without overriding that
-           cap here, the card below (forced to a true 100vw/100dvh) ends up
-           slightly bigger than its own <dialog> parent box, and that
-           leftover UA overflow:auto is what was producing the scrollbars */
+		/* The browser default caps dialog:modal at about 100% less its own
+           border and margin, and sets `overflow: auto`. The card below takes
+           a true 100vw and 100dvh, so without this override it outgrows its
+           parent box and that leftover overflow draws scrollbars. */
 		dialog#preview-dialog {
 			width: 100vw;
 			height: 100dvh;
@@ -171,11 +165,10 @@
 			box-sizing: border-box;
 		}
 
-		/* one flex item (the active step) plus .preview-actions share the
-           card's height; the step grows to fill whatever's left instead of
-           a fixed vw/dvh box that doesn't know how tall its own siblings
-           (tagline, hint text, buttons) actually are — that mismatch is
-           what caused the scrollbars */
+		/* The active step and .preview-actions share the card height, and the
+           step grows into what remains. A fixed vw or dvh box cannot: it
+           does not know how tall its siblings are, and that mismatch is what
+           drew the scrollbars. */
 		#source-step,
 		#crop-step,
 		#edit-step {
@@ -184,8 +177,8 @@
 			width: 100%;
 		}
 
-		/* plain boxes with no intrinsic aspect ratio: fill whatever space
-           the step grants them */
+		/* Plain boxes with no natural aspect ratio. They fill the space
+           that the step gives them. */
 		#source-drop-zone,
 		#crop-area {
 			flex: 1;
@@ -195,15 +188,12 @@
 			max-height: 100%;
 		}
 
-		/* unlike the two above, #edit-canvas has a real pixel aspect ratio
-           (set from the cropped image in preview.ts) — flex:1 (flex-basis:
-           0) lets it correctly share space with its siblings (tagline,
-           tool-picker/sliders) without a fixed vw/dvh box, but that same
-           flex-basis:0 doesn't reliably preserve aspect ratio for every
-           source image (most visible on a square crop, where any stretch
-           is obvious). object-fit: contain fixes that split: flexbox is
-           free to size the box however it wants, while the canvas's own
-           rendered bitmap stays letterboxed at its correct ratio inside it */
+		/* Unlike the two rules above, #edit-canvas has a real pixel aspect
+           ratio, set from the cropped image in preview.ts. `flex: 1` shares
+           space with its siblings without a fixed box, but that same
+           flex-basis: 0 does not hold the ratio for every image, most
+           visibly on a square crop. `object-fit: contain` splits the two:
+           flexbox sizes the box, the bitmap stays letterboxed inside it. */
 		#edit-canvas {
 			flex: 1;
 			min-height: 0;

--- a/client/export-options.ts
+++ b/client/export-options.ts
@@ -1,28 +1,24 @@
-// Export option types/constants/logic shared between client/export.ts (the
-// pre-export options dialog) and server/export.ts (the renderer + query-param
-// validation) — lives in client/ and is imported across the boundary by
-// server/export.ts, the same way client/animation-timeline.ts already is.
-// Kept dependency-free (no DOM, no Node/Bun APIs) so it's safe both bundled
-// into the browser and run directly under Bun on the server. Centralized
-// here (rather than duplicated in both files) so the GIF caps/ordering and
-// the clamping logic itself can't drift out of sync between client and
-// server the way hand-copied constants eventually would.
+// The export option types, constants, and logic, shared by the options
+// dialog in client/export.ts and the renderer in server/export.ts, which
+// imports this file across the boundary.
+//
+// It has no dependency, no DOM access, and no Bun or Node call, so it is safe
+// in the browser bundle and under Bun.
 
 export type Orientation = "landscape" | "portrait";
-// 720p is the max tier: background.mp4 itself is authored at 1280x720, so a
-// 1080p export would just be upscaling the background for no real gain
+// 720p is the highest tier. background.mp4 itself is 1280x720. A 1080p
+// export would only upscale the background, for no real gain.
 export type Resolution = "360p" | "480p" | "720p";
 export type FrameRate = 15 | 24 | 60;
 export type ExportFormat = "mp4" | "webm" | "gif";
 
 export const RESOLUTION_ORDER: Resolution[] = ["360p", "480p", "720p"];
 
-// GIF's palette-generation pass plus GIF's inherently poor compression for
-// video-like content make high resolution/framerate impractically slow and
-// huge: measured at ~146s/~324MB for 1080p/60fps, vs ~20s/~6MB for the same
-// settings as WebM. 720p is excluded entirely, but 360p/480p are both
-// allowed at full (unscaled) resolution — the client warns with a real size
-// estimate instead of the server silently capping resolution further.
+// GIF needs a palette pass and compresses video-like content poorly, so a
+// high resolution or frame rate becomes slow and very large: 1080p60
+// measured about 146s and 324MB, against about 20s and 6MB as WebM.
+// These caps exclude 720p. 360p and 480p run at full resolution, with a real
+// size estimate in the client instead of a further silent cap.
 export const GIF_MAX_RESOLUTION: Resolution = "480p";
 export const GIF_MAX_FPS: FrameRate = 24;
 
@@ -40,10 +36,7 @@ export function clampForGif(
 	};
 }
 
-// leaves room for ffmpeg's own post-last-frame encoding work (GIF's
-// palettegen/paletteuse pass especially) before jumping to a real 100% —
-// server/export.ts's renderFrames() caps per-frame progress here instead of
-// 100, then reports the real 100 once ffmpeg's process has actually exited;
-// client/export.ts's progress label swaps to "Finalizing…" in that gap
-// instead of sitting on a frozen percentage that reads as stuck/broken
+// Leaves room for the ffmpeg encode work after the last frame, which the GIF
+// palette passes dominate. renderFrames() stops here and reports the real 100
+// once ffmpeg exits; client/export.ts shows "Finalizing…" in that gap.
 export const FRAME_PROGRESS_CAP = 95;

--- a/client/export.ts
+++ b/client/export.ts
@@ -1,12 +1,11 @@
-// server-side export: hits /export/<hash>, which renders the animation
-// with a native canvas + ffmpeg (see server/export.ts) — no headless
-// browser, so this is fast enough that the progress dialog is only up for
-// roughly as long as the render + download take, not ~25s.
+// The client half of the export. It calls /export/<hash>, which renders the
+// animation with a native canvas and ffmpeg (see server/export.ts). No
+// headless browser, so the progress dialog is up only for render plus
+// download.
 
-// shared with server/export.ts (which imports the same file across the
-// client/server boundary, same as it already does for animation-timeline.ts)
-// so the option types, GIF caps/ordering, and the clamping logic itself
-// can't drift out of sync between the two — see export-options.ts
+// server/export.ts imports this same file across the client boundary, as it
+// already does for animation-timeline.ts, so the option types and the GIF
+// caps cannot drift apart. See export-options.ts.
 import {
 	clampForGif,
 	type ExportFormat,
@@ -19,9 +18,9 @@ import {
 	type Resolution,
 } from "./export-options";
 
-// dataset.value is always a plain string, even for the numeric FrameRate
-// options — this is the string-keyed form used for reading/writing DOM
-// attributes and building the size-estimate lookup key below
+// dataset.value is always a plain string, even for a numeric FrameRate
+// option. This type is the string form. The code reads and writes DOM
+// attributes with it. It also builds the size-estimate key below with it.
 type FrameRateValue = `${FrameRate}`;
 
 type ExportOptions = {
@@ -31,8 +30,9 @@ type ExportOptions = {
 	format: ExportFormat;
 };
 
-// keyed by the specific HTTP status server/server.ts's '/export/*' route can
-// return, so the user sees why it failed rather than one generic message
+// Keyed by the HTTP status values that the '/export/*' route of
+// server/server.ts returns. The user therefore sees the real reason. One
+// generic message would hide it.
 const EXPORT_ERROR_MESSAGES: Record<number, string> = {
 	404: "Couldn't find that image anymore — try uploading it again.",
 	429: "An export is already in progress. Please try again shortly.",
@@ -41,11 +41,10 @@ const DEFAULT_EXPORT_ERROR = "Couldn't export the animation. Please try again.";
 const EXPORT_ERROR_DISMISS_MS = 6000;
 const PROGRESS_POLL_MS = 200;
 
-// real measured GIF sizes (full 256-color palette, bayer_scale=5 dither, no
-// resolution scale-down) — only the combinations GIF actually allows
-// (resolution capped to 480p, fps capped to 24) have entries. Orientation
-// doesn't change total pixel count (e.g. 640x360 vs 360x640), so one
-// estimate per resolution/fps pair covers both.
+// Real measured GIF sizes, at the full 256-color palette with a
+// bayer_scale=5 dither and no downscale. Only the pairs that the GIF cap
+// allows have entries. Orientation does not change the pixel count, so one
+// estimate per pair covers both.
 const GIF_SIZE_ESTIMATE_MB: Partial<
 	Record<`${Resolution}:${FrameRateValue}`, number>
 > = {
@@ -88,13 +87,12 @@ export function initExport() {
 		"export-progress-label",
 	) as HTMLElement;
 
-	// no cancel action exists (aborting a render mid-flight isn't wired up),
-	// so block the Escape-key dismissal a native <dialog> offers by default —
-	// the dialog only closes when runExport() is done, via close() below
+	// No cancel action exists, so block the default Escape close of a native
+	// <dialog>. Only the close() call in runExport() below dismisses it.
 	progressDialog.addEventListener("cancel", (e) => e.preventDefault());
 
-	// reuses the same toast element preview.ts uses for upload errors — it's
-	// a generic dismissible message, not upload-specific despite the id
+	// Reuses the toast element that preview.ts uses for upload errors. The
+	// element shows any dismissible message. The id alone suggests otherwise.
 	const errorToast = document.getElementById("upload-error") as HTMLElement;
 	const errorToastText = errorToast.querySelector("p") as HTMLParagraphElement;
 	let errorToastTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -109,11 +107,9 @@ export function initExport() {
 		}, EXPORT_ERROR_DISMISS_MS);
 	}
 
-	// generalizes the erase/pick tool-button aria-pressed toggling in
-	// transparency.ts from two fixed buttons to N data-driven ones per group.
-	// Generic over the option-group's own value type (Orientation/Resolution/
-	// FrameRateValue/ExportFormat) so callers get a real typed value back
-	// instead of a bare string plus an `as` cast at every call site.
+	// Generalizes the aria-pressed toggle in transparency.ts from two fixed
+	// buttons to any number driven by data attributes. Generic over the value
+	// type of the group, so a caller gets a typed value back with no cast.
 	function selectOption<T extends string>(group: HTMLElement, value: T) {
 		for (const btn of group.querySelectorAll<HTMLButtonElement>("button")) {
 			btn.setAttribute("aria-pressed", String(btn.dataset.value === value));
@@ -139,9 +135,8 @@ export function initExport() {
 
 	const gifWarning = document.getElementById("gif-size-warning") as HTMLElement;
 
-	// shows a real size estimate whenever GIF is selected — full-resolution
-	// GIF has no automatic size mitigation (see GIF_SIZE_ESTIMATE_MB above),
-	// so the warning is what tells the user up front instead of a silent cap
+	// Shows a real size estimate for a GIF export. The encoder applies no
+	// automatic size reduction, so this warning is what tells the user.
 	function updateGifWarning() {
 		const isGif = getSelected<ExportFormat>(formatGroup) === "gif";
 		if (!isGif) {
@@ -159,11 +154,9 @@ export function initExport() {
 		gifWarning.hidden = false;
 	}
 
-	// disables the resolution/framerate options above the GIF cap when GIF
-	// is selected (falling back the current selection if it's now disabled),
-	// re-enables them otherwise. The fallback reuses clampForGif — the same
-	// function server/export.ts's query-param validation enforces with — so
-	// the two can't disagree on what counts as "too high" for GIF.
+	// Disables every resolution and frame rate above the GIF cap while GIF is
+	// selected, and moves the current selection down if it just went away.
+	// The move reuses clampForGif, so the server cannot disagree on the cap.
 	function applyGifCap() {
 		const isGif = getSelected<ExportFormat>(formatGroup) === "gif";
 
@@ -207,13 +200,10 @@ export function initExport() {
 	exportBtn.addEventListener("click", () => {
 		if (exportBtn.disabled) return;
 
-		// default orientation is keyed off device type (mobile -> portrait,
-		// everything else -> landscape), not the current viewport orientation
-		// — a deliberate product choice, still overridable in the dialog.
-		// Same isMobile check as preview.ts's source-step (hover:none +
-		// coarse pointer, without a fine pointer also present, to avoid
-		// misclassifying a touchscreen laptop/tablet that also has a
-		// mouse/trackpad attached).
+		// The default orientation follows the device type, not the current
+		// viewport: portrait on mobile, landscape elsewhere. A deliberate
+		// product choice, still changeable in the dialog. Same isMobile test
+		// as the source step of preview.ts.
 		const isMobile =
 			window.matchMedia("(hover: none) and (pointer: coarse)").matches &&
 			!window.matchMedia("(any-pointer: fine)").matches;
@@ -258,7 +248,7 @@ export function initExport() {
 			const { percent } = (await res.json()) as { percent: number };
 			setProgress(percent);
 		} catch {
-			// a missed tick just leaves the last known percentage on screen
+			// A missed tick leaves the last known percentage on screen.
 		}
 	}
 
@@ -270,8 +260,8 @@ export function initExport() {
 	}: ExportOptions) {
 		exportBtn.disabled = true;
 		setProgress(0);
-		// showModal() makes the rest of the page inert on its own — nothing
-		// else is reachable by click or keyboard while a render is in flight
+		// showModal() makes the rest of the page inert by itself. No click
+		// and no key can reach another element during a render.
 		progressDialog.showModal();
 		const progressTimer = setInterval(pollProgress, PROGRESS_POLL_MS);
 

--- a/client/preview.ts
+++ b/client/preview.ts
@@ -1,5 +1,5 @@
-// preview dialog: crop the picked image (cropperjs) then optionally
-// erase/color-pick it to transparent, before actually uploading it
+// The preview dialog: pick a file, crop it with cropperjs, optionally erase
+// or color-pick it to transparent, then upload.
 import Cropper, {
 	type CropperCanvas,
 	type CropperImage,
@@ -7,12 +7,12 @@ import Cropper, {
 } from "cropperjs";
 import { initTransparencyTools } from "./transparency";
 
-// the image is shown at this fraction of the crop zone, so its boundary
-// stays visible around the image instead of the image filling it edge-to-edge
+// The dialog shows the image at this fraction of the crop zone. The
+// boundary of the zone therefore stays visible around the image.
 const IMAGE_FIT_SCALE = 0.8;
 
-// matches the `error` query param the server redirects to '/' with (see
-// server.ts's '/upload' handler)
+// Matches the `error` query parameter of the redirect to '/'. See the
+// '/upload' handler in server.ts.
 const UPLOAD_ERROR_MESSAGES: Record<string, string> = {
 	invalid_type: "Only PNG images are supported. Please try again.",
 	too_large: "This image is too large. Please try again with a smaller one.",
@@ -24,17 +24,16 @@ const NETWORK_ERROR_MESSAGE = "Couldn't reach the server. Please try again.";
 
 const UPLOAD_ERROR_DISMISS_MS = 6000;
 
-// classifies a completed '/upload' fetch response into either a successful
-// hash or a message to show — kept separate from the dialog-closing/
-// onUploaded side effects that act on it
+// Classifies a finished '/upload' response into a hash or a message. The
+// dialog close and the onUploaded call stay outside this function.
 function classifyUploadResult(
 	res: Response,
 ): { hash: string } | { message: string } {
 	if (res.status >= 500) return { message: SERVER_ERROR_MESSAGE };
 
-	// fetch already followed the 303, so this is the final URL — a bare '/'
-	// means the upload was rejected server-side (see the `error` query
-	// param for why)
+	// fetch already followed the 303, so this is the final URL. A bare '/'
+	// means the server rejected the upload. The `error` query parameter
+	// gives the reason.
 	const url = new URL(res.url);
 	const hash = url.pathname.slice(1);
 	if (hash) return { hash };
@@ -136,15 +135,14 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 				return;
 			}
 		}
-		// clipboard had content but none of it was an image (e.g. copied text)
+		// The clipboard held content, but no image. Copied text does this.
 		showSourceError("Clipboard doesn't contain an image.");
 	}
 
 	type Step = "source" | "crop" | "edit";
 
-	// centralizes the per-step hidden/visible state for the dialog's three
-	// steps and their nav buttons, instead of each step-entry point setting
-	// all six flags by hand
+	// Holds the visible state of the three steps and their navigation buttons
+	// in one place, instead of six flags set by hand at each entry point.
 	function setStep(step: Step) {
 		sourceStep.hidden = step !== "source";
 		cropStep.hidden = step !== "crop";
@@ -163,19 +161,17 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 
 	function openSourceStep() {
 		setStep("source");
-		// a previous upload in this same dialog session may have left this
-		// disabled — reset it so a fresh upload isn't stuck uncancelable
+		// An earlier upload in this dialog session can leave this button
+		// disabled. The reset keeps a new upload cancelable.
 		cancelBtn.disabled = false;
 		previewDialog.showModal();
 	}
 
-	// drag & drop and clipboard paste (the whole point of the source step)
-	// aren't reachable when there's no precise pointer available at all —
-	// computed once since input capability doesn't change over a dialog
-	// session. Requiring *both* a coarse/no-hover primary pointer AND no
-	// fine pointer available as a secondary input (any-pointer) avoids
-	// misclassifying a hybrid touchscreen laptop/tablet that also has a
-	// mouse or trackpad attached, which still gets the full desktop flow
+	// A device with no precise pointer can reach neither drag and drop nor
+	// paste, which are the purpose of the source step. Computed once: the
+	// input hardware does not change during a dialog session.
+	// Both queries must agree. The any-pointer half keeps a touchscreen
+	// laptop with a mouse attached on the full desktop flow.
 	const isMobile =
 		window.matchMedia("(hover: none) and (pointer: coarse)").matches &&
 		!window.matchMedia("(any-pointer: fine)").matches;
@@ -206,7 +202,8 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 		if (file) openPreviewWithFile(file);
 	};
 
-	// covers both the Cancel button and native Escape-to-close on <dialog>
+	// Covers the Cancel button. Also covers the native Escape key close of
+	// the <dialog> element.
 	previewDialog.onclose = () => {
 		cropper?.destroy();
 		cropper = null;
@@ -221,8 +218,8 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 
 	function showCropStep() {
 		setStep("crop");
-		// a previous upload in this same dialog session may have left these
-		// set — reset them so a fresh upload isn't stuck disabled/loading
+		// An earlier upload in this dialog session can leave these flags
+		// set. The reset keeps a new upload usable.
 		uploadBtn.disabled = false;
 		uploadBtn.classList.remove("is-loading");
 		cancelBtn.disabled = false;
@@ -232,23 +229,18 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 		const thisCropper = new Cropper(previewImg, { container: cropArea });
 		cropper = thisCropper;
 
-		// by default, select exactly the image's own bounds — a plain
-		// full-canvas selection would extend into the letterboxed empty
-		// margin whenever the image's aspect ratio doesn't match the crop
-		// zone's, adding that empty area as extra transparent space to
-		// anyone who clicks Next without adjusting the crop themselves
+		// Selects the bounds of the image exactly. A plain full-canvas
+		// selection would reach into the empty letterbox margin whenever the
+		// two aspect ratios differ, adding transparent space to the result.
 		const cropperImage = thisCropper.getCropperImage() as CropperImage;
 		const selection = thisCropper.getCropperSelection() as CropperSelection;
 		cropperImage.$ready(() => {
-			// cropper.js's own internal image-load handler also re-centers
-			// the image (to a plain, unscaled "contain" fit) — on a cached
-			// image (e.g. re-entering this step via Back) that handler can
-			// fire *after* $ready's callback instead of before, silently
-			// undoing our scale/selection if we apply them immediately. Two
-			// animation frames reliably land after that internal handler.
+			// The internal image-load handler of cropper.js recenters the
+			// image at an unscaled "contain" fit, and on a cached image it
+			// can run *after* $ready. Two frames land after it reliably.
 			requestAnimationFrame(() => {
 				requestAnimationFrame(() => {
-					if (cropper !== thisCropper) return; // superseded by a newer step
+					if (cropper !== thisCropper) return; // A newer step replaced this one.
 					cropperImage.$center("contain").$scale(IMAGE_FIT_SCALE);
 					const canvasRect = (
 						thisCropper.getCropperCanvas() as CropperCanvas
@@ -278,16 +270,17 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 
 		setStep("edit");
 
-		// must run after editStep is unhidden: the erase cursor is sized from
-		// the canvas's displayed rect, which is 0x0 while hidden
+		// Must run after editStep becomes visible. The code sizes the erase
+		// cursor from the displayed rect of the canvas. That rect is 0x0
+		// while the step stays hidden.
 		resetTransparencyTools();
 	};
 
 	backBtn.onclick = showCropStep;
 
 	uploadBtn.onclick = async () => {
-		// prevent double-submit and a stray navigation if Cancel/Back were
-		// clicked while the upload is still in flight
+		// Stops a second submit. Also stops a stray navigation from a click
+		// on Cancel or Back during the upload.
 		uploadBtn.disabled = true;
 		uploadBtn.classList.add("is-loading");
 		cancelBtn.disabled = true;
@@ -298,8 +291,8 @@ export function initPreviewDialog(onUploaded: (hash: string) => void) {
 		});
 
 		const formData = new FormData();
-		// the server only accepts PNG uploads, keyed off this filename's
-		// extension (not the Blob's own declared `type`)
+		// The server accepts PNG uploads only. This filename gives the
+		// multipart part its image/png Content-Type.
 		formData.set("file-upload", blob, "cropped.png");
 
 		try {

--- a/client/script.ts
+++ b/client/script.ts
@@ -30,8 +30,8 @@ for (let i = nbPictures; i >= 1; i--) {
 
 requireElement<HTMLElement>("app-version").textContent = `v${version}`;
 
-// copy-link: reuses the same toast element preview.ts/export.ts use for
-// error messages — a generic dismissible message, not error-specific
+// The copy-link control. It reuses the toast element of preview.ts and
+// export.ts. That element shows any dismissible message, not errors alone.
 const copyLinkBtn = requireElement<HTMLButtonElement>("copy-link-btn");
 const copyToast = requireElement<HTMLElement>("upload-error");
 const copyToastText = copyToast.querySelector("p") as HTMLParagraphElement;
@@ -46,9 +46,8 @@ function showCopyToast() {
 }
 
 copyLinkBtn.addEventListener("click", async () => {
-	// clipboard access needs a secure context (HTTPS/localhost) and can be
-	// denied by the user, so both are worth telling apart rather than one
-	// generic failure message
+	// Clipboard access needs a secure context, over HTTPS or on localhost.
+	// The user can also deny it. Each case deserves its own message.
 	if (!navigator.clipboard) {
 		copyToastText.textContent = "Clipboard isn't available in this browser.";
 		copyToast.classList.remove("toast-success");
@@ -74,9 +73,9 @@ initExport();
 initVolumeControl();
 
 /**
- * Swaps in a freshly uploaded image without a full page reload: updates the
- * pictures' src, updates the URL to match (so the link stays shareable),
- * and launches the animation right away so the upload feels instant.
+ * Swaps in a new upload without a page reload: updates each picture src,
+ * updates the URL so the link stays shareable, then launches the animation
+ * at once so the upload feels instant.
  */
 function applyUploadedImage(hash: string) {
 	const src = `uploads/${hash}`;

--- a/client/transparency.ts
+++ b/client/transparency.ts
@@ -1,10 +1,12 @@
-// erase/color-pick transparency editing on a canvas, with undo/redo history
+// Transparency editing on a canvas. It offers an erase tool and a
+// color-pick tool. It keeps an undo history and a redo history.
 
 type Tool = "erase" | "pick";
 
 const MAX_HISTORY = 20;
 
-// draws one erase dab (destination-out) into ctx at (x, y) with the given radius
+// Draws one erase mark into ctx at (x, y), with the given radius. It uses
+// the destination-out composite operation.
 function eraseAt(
 	ctx: CanvasRenderingContext2D,
 	x: number,
@@ -19,8 +21,8 @@ function eraseAt(
 	ctx.restore();
 }
 
-// makes every pixel within `tolerance` color-distance of (x, y) transparent
-// (simple Euclidean RGB distance, no edge feathering)
+// Makes every pixel transparent within `tolerance` color distance of (x, y).
+// The measure is a plain Euclidean RGB distance. It feathers no edge.
 function pickColorAt(
 	ctx: CanvasRenderingContext2D,
 	canvas: HTMLCanvasElement,
@@ -74,7 +76,8 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		redoBtn.disabled = redoStack.length === 0;
 	}
 
-	// snapshots the canvas before an edit starts, so it can be undone as one step
+	// Takes a canvas snapshot before an edit starts. One undo step therefore
+	// reverses the whole edit.
 	function pushHistory() {
 		undoStack.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
 		if (undoStack.length > MAX_HISTORY) undoStack.shift();
@@ -98,11 +101,9 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		updateHistoryButtons();
 	};
 
-	// the mobile fullscreen dialog styles #edit-canvas with object-fit:
-	// contain, which can letterbox the rendered bitmap inside the element's
-	// own box (its aspect ratio no longer has to match the canvas's) — this
-	// resolves the actual rendered content rect so pointer math and cursor
-	// sizing scale against it instead of the (possibly larger) element box
+	// The mobile dialog styles #edit-canvas with `object-fit: contain`, which
+	// can letterbox the bitmap inside the element box. This returns the real
+	// content rect, so pointer math and cursor size scale against it.
 	function contentRect() {
 		const rect = canvas.getBoundingClientRect();
 		const scale = Math.min(
@@ -119,10 +120,9 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		};
 	}
 
-	// draws the brush outline as the canvas cursor itself, so hovering shows
-	// exactly what the next erase will cover (scaled from canvas pixels to
-	// displayed CSS pixels, since the canvas can be shown smaller than its
-	// backing resolution)
+	// Draws the brush outline as the canvas cursor, so a hover shows the exact
+	// area of the next erase. The radius scales from canvas pixels to CSS
+	// pixels: the canvas can appear smaller than its backing resolution.
 	function updateEraseCursor() {
 		if (tool !== "erase") return;
 
@@ -130,9 +130,9 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		if (!Number.isFinite(radius) || radius <= 0) return;
 
 		const displayRadius = (radius * contentRect().width) / canvas.width;
-		// rasterize at devicePixelRatio so the outline stays crisp (not
-		// blurry-upscaled) on high-DPI screens; cursor hotspot/size are in
-		// raster pixels, so everything below is scaled by dpr together
+		// Rasterizes at devicePixelRatio so the outline stays sharp on a
+		// high-DPI screen. Hotspot and size are in raster pixels, so every
+		// value below scales by dpr together.
 		const dpr = window.devicePixelRatio || 1;
 		const size = (Math.ceil(displayRadius) * 2 + 2) * dpr;
 		const center = size / 2;
@@ -154,10 +154,9 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 	eraseBtn.onclick = () => setTool("erase");
 	pickBtn.onclick = () => setTool("pick");
 
-	// rect is passed in (rather than calling contentRect() here) so a drag
-	// can compute it once at pointerdown and reuse it for every pointermove —
-	// getBoundingClientRect() can force a layout reflow, too costly to pay
-	// on every move event of a hot drag loop
+	// The caller passes `rect` in, so a drag computes it once at pointerdown
+	// and reuses it. getBoundingClientRect() can force a layout reflow, too
+	// costly for every event of a drag loop.
 	function canvasPoint(
 		e: PointerEvent,
 		rect: ReturnType<typeof contentRect>,
@@ -169,7 +168,7 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 	}
 
 	canvas.onpointerdown = (e: PointerEvent) => {
-		// computed once for the whole stroke, not per move — see canvasPoint
+		// Computed once for the whole stroke, not per move. See canvasPoint.
 		const rect = contentRect();
 		const point = canvasPoint(e, rect);
 		pushHistory();
@@ -188,8 +187,8 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 		eraseAt(ctx, point.x, point.y, Number(eraseSizeInput.value));
 		canvas.setPointerCapture(e.pointerId);
 
-		// touch pointermove can fire faster than the display refreshes;
-		// coalesce to at most one erase draw per frame instead of one per event
+		// A touch pointermove event can arrive faster than the display
+		// refreshes. This code draws at most one erase mark per frame.
 		let pendingPoint: { x: number; y: number } | null = null;
 		let rafScheduled = false;
 		const onMove = (moveEvent: PointerEvent) => {
@@ -208,11 +207,9 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 				}
 			});
 		};
-		// 'lostpointercapture' — rather than 'pointerup' alone — is what
-		// actually guarantees cleanup: it fires whenever capture ends for
-		// any reason (release, pointercancel from a browser gesture/palm
-		// rejection, programmatic release), so drag state can never get
-		// stuck with a dangling pointermove listener
+		// 'lostpointercapture' guarantees the cleanup where 'pointerup'
+		// alone does not: the browser sends it whenever capture ends, for a
+		// release, a palm rejection, or a release from code.
 		const onLostCapture = () => {
 			canvas.removeEventListener("pointermove", onMove);
 			canvas.removeEventListener("lostpointercapture", onLostCapture);
@@ -224,7 +221,7 @@ export function initTransparencyTools(canvas: HTMLCanvasElement) {
 	updateHistoryButtons();
 
 	return {
-		// clears tool/undo state for a freshly (re-)cropped image
+		// Clears the tool state and the undo state for a new crop.
 		reset() {
 			setTool("erase");
 			undoStack = [];

--- a/client/volume.ts
+++ b/client/volume.ts
@@ -1,5 +1,5 @@
-// background-video volume control that lives in the persistent
-// #quick-actions dock — see export.ts for the popover pattern this mirrors
+// The volume control of the background video, in the persistent
+// #quick-actions dock.
 
 import { getVideoElement } from "./animation";
 
@@ -17,8 +17,8 @@ export function initVolumeControl() {
 		"volume-slider",
 	) as HTMLInputElement;
 
-	// reflect whatever animation.ts actually set as the default rather than
-	// hardcoding a second default here that could drift out of sync
+	// Reads the default that animation.ts set. A second default here could
+	// drift away from that value.
 	volumeSlider.value = String(Math.round(video.volume * 100));
 
 	function setMenuOpen(open: boolean) {
@@ -26,8 +26,8 @@ export function initVolumeControl() {
 		volumeBtn.setAttribute("aria-expanded", String(open));
 	}
 
-	// volume 0 and .muted both play silently, so either one should read as
-	// "muted" in the UI even if only one of them is technically true
+	// A volume of 0 plays silently. The .muted flag does the same. Either
+	// one alone therefore reads as "muted" in the user interface.
 	function isMuted(): boolean {
 		return video.muted || video.volume === 0;
 	}
@@ -46,14 +46,13 @@ export function initVolumeControl() {
 		setMenuOpen(!!volumeMenu.hidden);
 	});
 
-	// closes the popover on any click outside the group, same as export.ts
+	// Closes the popover on a click outside the group, as export.ts does.
 	document.addEventListener("click", (e) => {
 		if (!volumeGroup.contains(e.target as Node)) setMenuOpen(false);
 	});
 
-	// Escape closes the popover regardless of which element inside it is
-	// focused, so keyboard users get the same dismissal outside-click gives
-	// mouse users
+	// Escape closes the popover from any focused element inside it, so a
+	// keyboard user gets what an outside click gives a mouse user.
 	document.addEventListener("keydown", (e) => {
 		if (e.key === "Escape" && !volumeMenu.hidden) setMenuOpen(false);
 	});
@@ -63,9 +62,8 @@ export function initVolumeControl() {
 		updateMuteUI();
 	});
 
-	// dragging the slider always implies "I want sound", matching native
-	// media-player convention (un-mutes even if dragged back down to 0,
-	// which then just reads as muted again via isMuted()'s volume===0 check)
+	// A drag always means "I want sound", as a native media player does. It
+	// unmutes even at 0, which isMuted() then reads as muted again.
 	volumeSlider.addEventListener("input", () => {
 		video.volume = Number(volumeSlider.value) / 100;
 		video.muted = false;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-# IMPORTANT: UPLOADS_DIR falls back to /tmp/shooting-stars-uploads if unset.
-# Production deployments MUST set UPLOADS_DIR in .env to the real persistent
-# host path — otherwise uploads silently start landing in an ephemeral
-# directory instead of wherever they were being served from before.
+# IMPORTANT: UPLOADS_DIR defaults to /tmp/shooting-stars-uploads.
+# A production deployment MUST set it in .env to the real persistent host
+# path. Uploads otherwise land in a temporary directory instead.
 services:
   bun:
     build: .
@@ -14,10 +13,9 @@ services:
     volumes:
       - ${UPLOADS_DIR:-/tmp/shooting-stars-uploads}:/app/uploads
     healthcheck:
-      # wget/curl aren't installed in oven/bun:1 (Debian, since the export
-      # feature needed a non-Alpine base — see Dockerfile) the way they were
-      # on the old oven/bun:1-alpine image, so use Bun's own fetch() instead
-      # of adding a package just for this
+      # The oven/bun:1 image holds no wget and no curl, unlike the old
+      # Alpine one (see Dockerfile). One healthcheck does not justify another
+      # package, so use the fetch() of Bun instead.
       test:
         [
           "CMD",

--- a/justfile
+++ b/justfile
@@ -7,74 +7,74 @@ docker_run := docker_compose + " run \
     --rm \
     bun"
 
-# print recipe names and comments as help
+# Prints the recipe names and their comments as help.
 help:
     @just --list
 
-# build project images
+# Builds the project images.
 build:
     @echo "Building Shooting Stars..."
     {{ docker_compose }} build
 
-# run Shooting Stars application
+# Runs the Shooting Stars application.
 start:
     @echo "Launching Shooting Stars (production mode)..."
     {{ docker_compose }} up -d
 
-# run Shooting Stars in dev mode (live HMR via `bun --hot`)
+# Runs Shooting Stars in dev mode. `bun --hot` gives live HMR.
 dev:
     @echo "Launching Shooting Stars (dev mode, Bun HMR)..."
     {{ docker_compose }} --profile dev up bun-dev
 
-# access an interactive shell inside the app container
+# Opens an interactive shell in the app container.
 shell:
     @echo "Running shell on bun container..."
     {{ docker_run }} /bin/sh
 
-# type-check + lint/format-check the sources (bun runs .ts directly either way, this only checks)
+# Checks the types, the lint rules, and the format. This recipe only reports.
 check:
     @echo "Checking..."
     {{ docker_compose }} --profile dev run --rm bun-dev bun run check
 
-# auto-fix lint/format issues (biome)
+# Corrects the lint problems and the format problems, with Biome.
 format:
     @echo "Formatting..."
     {{ docker_compose }} --profile dev run --rm bun-dev bun run lint:fix
 
-# regenerate client/css/stars.css from server/keyframes.ts
+# Regenerates client/css/stars.css from server/keyframes.ts.
 generate-css:
     @echo "Generating stars.css..."
     {{ docker_compose }} --profile dev run --rm bun-dev bun run generate:css
 
-# run the test suite (bun:test)
+# Runs the test suite, with bun:test.
 test:
     @echo "Running tests..."
     {{ docker_compose }} --profile dev run --rm bun-dev bun test
 
-# run the test suite with a coverage report (text)
+# Runs the test suite with a coverage report, as text.
 test-coverage:
     @echo "Running tests with coverage..."
     {{ docker_compose }} --profile dev run --rm bun-dev bun test --coverage
 
-# build & run Shooting Stars application (production mode)
+# Builds and runs the Shooting Stars application, in production mode.
 up: build start
 
-# stop the app and remove containers (preserves data volumes)
+# Stops the app and removes the containers. Keeps the data volumes.
 down:
     @echo "Stopping Shooting Stars and cleaning containers..."
     {{ docker_compose }} --profile "*" down --remove-orphans
 
-# stop the app, remove containers and volumes (clean slate)
+# Stops the app. Removes the containers and the volumes.
 down_clean:
     @echo "Stopping Shooting Stars and cleaning containers and volumes..."
     {{ docker_compose }} --profile "*" down -v --remove-orphans
 
-# update lock file
+# Updates the lock file.
 lock:
     @echo "Updating bun.lock..."
     {{ docker_run }} bun install
 
-# clean up Docker environment
+# Cleans up the Docker environment.
 clean: down_clean
     @echo "Cleaning Docker environment..."
     docker image prune -af

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,6 +1,6 @@
-# Runs clean_old_uploads.sh once a day. ponytail: a sleep loop instead of a
-# real crond entry — one less moving part for a single daily job; swap for
-# crond if this ever needs a real schedule (specific time, multiple jobs).
+# Runs clean_old_uploads.sh once a day. ponytail: a sleep loop, not a real
+# crond entry. One daily job needs no scheduler. Change to crond for a real
+# schedule, for example a specific time or several jobs.
 FROM alpine:3
 RUN apk add --no-cache findutils
 COPY clean_old_uploads.sh /clean_old_uploads.sh

--- a/scripts/generate-stars-css.ts
+++ b/scripts/generate-stars-css.ts
@@ -1,20 +1,10 @@
-// Generates client/css/stars.css from server/keyframes.ts's ANIMATIONS data
-// — keyframes.ts is the canonical animation dataset (see its header
-// comment); this script is the other direction of that relationship, so
-// the two files can never drift apart silently again.
+// Generates client/css/stars.css from the ANIMATIONS data in
+// server/keyframes.ts. Run it plain to write the file, or with `--check` for
+// the drift check that `just check` runs.
 //
-// Run directly (`bun scripts/generate-stars-css.ts`) to write the file, or
-// with `--check` (`bun scripts/generate-stars-css.ts --check`, wired as
-// `verify:css` in package.json and folded into `just check`) to compare
-// the generated text against what's on disk and exit non-zero without
-// writing — the drift check.
-//
-// Byte-identical output isn't the goal (Biome reformats the file anyway,
-// see `just format`); behaviorally identical CSS is: same property values
-// at the same keyframe percentages. `scale(x, y)` is always emitted in
-// two-argument form, even where the original hand-authored CSS used
-// `scale(n)` or `scaleX(n)` — computationally identical, no need to
-// reconstruct which literal shorthand was originally used.
+// Equal behavior is the goal, not byte-identical output: Biome reformats the
+// file anyway. This script always emits the two-argument `scale(x, y)` form,
+// which computes the same result as the original `scale(n)`.
 
 import {
 	ANIMATIONS,
@@ -22,8 +12,8 @@ import {
 	type PictureAnimation,
 } from "../server/keyframes";
 
-// className is identical to the ANIMATIONS key for every entry; only the
-// @keyframes animation-name itself differs from the class name for some.
+// className matches the ANIMATIONS key for every entry. Only the @keyframes
+// animation-name differs from the class name, and only for some entries.
 const ANIMATION_NAME: Record<string, string> = {
 	spaceone_1: "spaceone",
 	dolphins_1: "dolphins-one",

--- a/server/export-worker.ts
+++ b/server/export-worker.ts
@@ -1,8 +1,8 @@
-// Entry point for the worker thread spawned by renderExportInWorker() in
-// server/export.ts — runs the actual canvas-rendering + ffmpeg pipeline off
-// the thread that serves HTTP requests. Communicates back over parentPort
-// (progress ticks, then a final result) rather than a return value, since
-// worker_threads results are message-based, not a plain awaited call.
+// The entry point for the worker thread. renderExportInWorker() in
+// server/export.ts starts it. It runs the canvas rendering and the ffmpeg
+// pipeline off the thread that serves HTTP requests. It reports back over
+// parentPort: progress ticks, then a final result. It returns no value. A
+// worker_threads result is a message, not an awaited call.
 
 import { parentPort, workerData } from "node:worker_threads";
 import type { ExportJob } from "./export";

--- a/server/export.ts
+++ b/server/export.ts
@@ -1,11 +1,8 @@
-// Server-side animation export, without a headless browser: renders
-// transparent RGBA frames with a native canvas (replicating stars.css's
-// keyframes + animation.ts's stage timeline — see server/keyframes.ts) and
-// pipes them into a single ffmpeg process that composites them over
-// background.mp4 and encodes the result. This is why it can be near-instant
-// where the old (abandoned) approach — recording the real page with
-// Playwright — took ~20-27s per export: there's no real-time playback or
-// browser to wait on, just compositing + a fast software encode.
+// Animation export on the server, without a headless browser. A native
+// canvas renders transparent RGBA frames from server/keyframes.ts. One
+// ffmpeg process composites them over background.mp4 and encodes the result.
+// The old Playwright approach recorded the real page and needed 20 to 27
+// seconds. This one waits on no real-time playback.
 
 import { join } from "node:path";
 import { Worker } from "node:worker_threads";
@@ -14,11 +11,9 @@ import {
 	ANIMATION_TIMELINE,
 	pictureAnimationKey,
 } from "../client/animation-timeline";
-// re-exported below (via `export *`) so server.ts/export-worker.ts's
-// existing `from "./export"` imports don't need to change — this file
-// stays the single import point for server-side export code, it just
-// sources the option types/GIF caps/clamping logic from client/ now
-// instead of defining its own copy (see export-options.ts for why)
+// The `export *` below re-exports these names, so the `from "./export"`
+// imports in server.ts and export-worker.ts need no change. This file stays
+// the single import point for the export code of the server.
 import {
 	type ExportFormat,
 	FRAME_PROGRESS_CAP,
@@ -38,11 +33,9 @@ export const DEFAULT_RESOLUTION: Resolution = "480p";
 export const DEFAULT_FPS: FrameRate = 24;
 export const DEFAULT_FORMAT: ExportFormat = "mp4";
 
-// 480p is the original/default tier — kept unchanged from before resolution
-// was configurable, for continuity with any bookmarked/shared export
-// behavior. Every tier matches the export viewport's own aspect ratio
-// (16:9 landscape / 9:16 portrait); bgFilter below always scales+crops the
-// background down/up to match, regardless of orientation or tier.
+// 480p is the original default tier, kept so old shared exports still behave
+// the same way. Every tier matches the viewport aspect ratio: 16:9 landscape,
+// 9:16 portrait. The background filter below scales and crops to match.
 const VIEWPORTS: Record<
 	Orientation,
 	Record<Resolution, { width: number; height: number }>
@@ -59,16 +52,16 @@ const VIEWPORTS: Record<
 	},
 };
 
-// matches base.css's `--travel-scale: clamp(0.25, calc(100vw / 1400px), 1)`
-// — computed once per orientation since the export always uses a fixed
-// viewport size (no responsive resize mid-render)
+// Matches `--travel-scale: clamp(0.25, calc(100vw / 1400px), 1)` in base.css.
+// The code computes it once per orientation. The export viewport has a fixed
+// size. It never resizes during a render.
 function travelScale(viewportWidth: number): number {
 	return Math.min(1, Math.max(0.25, viewportWidth / 1400));
 }
 
-// matches base.css's `img { max-width: calc(30% / var(--travel-scale)) }`
-// (and max-height, same formula against viewport height) — the box an
-// uploaded image is fit into before the keyframe transform applies
+// Matches `img { max-width: calc(30% / var(--travel-scale)) }` in base.css.
+// The max-height rule uses the same formula against the viewport height.
+// An upload fits into this box before the keyframe transform applies.
 function pictureBox(
 	viewport: { width: number; height: number },
 	scale: number,
@@ -79,17 +72,17 @@ function pictureBox(
 	};
 }
 
-// the last ANIMATION_TIMELINE offset is the loop point (stage swaps back
-// to "init", matching the background video's own length / 'ended' event)
+// The last ANIMATION_TIMELINE offset is the loop point. The stage returns to
+// "init" there. That offset matches the length of the background video.
 const EXPORT_DURATION_MS = Math.max(
 	...Object.keys(ANIMATION_TIMELINE).map(Number),
 );
 
 const pictureIds = ["pict1", "pict2", "pict3", "pict4", "pict5", "pict6"];
 
-// sorted ascending so findStage can do a simple linear scan for the last
-// entry whose start is <= the current frame time — 8 entries, no need for
-// anything fancier
+// Sorted upward, so findStage can scan linearly. It takes the last entry
+// that starts at or before the current frame time. The list holds 8 entries.
+// A faster search gains nothing here.
 const timeline = Object.entries(ANIMATION_TIMELINE)
 	.map(([ms, stage]) => ({ startMs: Number(ms), ...stage }))
 	.sort((a, b) => a.startMs - b.startMs);
@@ -149,21 +142,16 @@ async function renderFrames(
 			if (frame.opacity <= 0) continue;
 
 			ctx.save();
-			// base position: img is centered in the viewport (base.css's
-			// inset:0 + margin:auto), then the individual `scale` CSS
-			// property (--travel-scale) applies, then the keyframe's own
-			// transform applies on top — travel-scale ends up multiplying
-			// the keyframe's translate distances too (confirmed against the
-			// comment in base.css: "scales the whole rendered transform
-			// down proportionally").
+			// Base position: base.css centers the image, then --travel-scale
+			// applies, then the keyframe transform. travel-scale therefore
+			// also multiplies the keyframe translate distances.
 			ctx.translate(viewport.width / 2, viewport.height / 2);
 			ctx.scale(scale, scale);
 			ctx.translate(frame.x, frame.y);
-			// stars.css doesn't use one consistent transform-function order
-			// across animations (see keyframes.ts's TransformOrder comment)
-			// — CSS composes functions in written order, so the ctx call
-			// order below must match each animation's own order, not a
-			// single hardcoded sequence.
+			// stars.css uses no single transform function order across the
+			// animations. See the TransformOrder comment in keyframes.ts.
+			// CSS composes these functions in written order. The ctx calls
+			// below must therefore follow the order of each animation.
 			const rotateRad = (frame.rotateDeg * Math.PI) / 180;
 			if (anim.transformOrder === "scale-rotate") {
 				ctx.scale(frame.scaleX, frame.scaleY);
@@ -191,16 +179,10 @@ async function renderFrames(
 		drawFrame(frameTimeMs);
 
 		await onFrame(canvas.data());
-		// frames are piped into ffmpeg as they're generated (not rendered
-		// up front then encoded in a second pass), so "frames sent so far"
-		// tracks real encode progress closely enough — no need to parse
-		// ffmpeg's own stderr progress output for this. Capped below 100
-		// (not a full 0-100 scale) since ffmpeg still has to finish encoding
-		// after the last frame is piped in — GIF's palettegen/paletteuse pass
-		// in particular keeps running well after every frame has arrived, so
-		// hitting 100% here would leave the UI stuck at "100%" for that whole
-		// remaining stretch. renderExport() emits the real 100% once ffmpeg's
-		// process has actually exited.
+		// Frames go into ffmpeg as they render, so the sent count tracks
+		// encode progress closely enough to parse no stderr output.
+		// The scale stops below 100 because ffmpeg keeps encoding after the
+		// last frame. renderExport() reports the real 100 once it exits.
 		onProgress?.(Math.round(((n + 1) / totalFrames) * FRAME_PROGRESS_CAP));
 	}
 }
@@ -227,10 +209,10 @@ async function runFfmpeg(
 
 const backgroundVideoPath = `${import.meta.dir}/../client/public/videos/background.mp4`;
 
-// background.mp4's own AAC audio track can be copied byte-for-byte into an
-// MP4 output (same container family), but WebM can't carry AAC at all —
-// vorbis is the traditional, always-available WebM audio codec, so that
-// format re-encodes instead of copying.
+// An MP4 output can copy the AAC audio track of background.mp4 byte for
+// byte. Both files use the same container family. WebM cannot carry AAC at
+// all. Vorbis is the traditional WebM audio codec. It is always available.
+// The WebM path therefore re-encodes the audio.
 const ENCODE_ARGS: Record<"mp4" | "webm", string[]> = {
 	mp4: ["-c:a", "copy", "-c:v", "libx264", "-preset", "ultrafast"],
 	webm: [
@@ -284,20 +266,11 @@ function buildFilterComplex(
 	fps: FrameRate,
 	format: ExportFormat,
 ): string {
-	// cover-crops the source background.mp4 (1280x720) down/up to the
-	// export's viewport — for portrait this also reshapes the aspect ratio,
-	// matching the CSS `min-width/min-height: 100%` "cover" sizing the
-	// <video> gets in the browser; for landscape it's just a scale (16:9
-	// already matches every landscape tier, so the crop is a no-op). The
-	// trailing fps filter resamples the background from its own native
-	// ~23.976fps up (or down) to our chosen fps *before* the overlay filter
-	// runs — without it, overlay's output cadence is driven by its *main*
-	// ([0:v], the background) input, so at fps=60 it would still only
-	// sample our 60fps picture-overlay stream ~24 times/sec (confirmed by
-	// testing: framemd5 showed heavy frame duplication, one identical frame
-	// repeated 331 times, at 60fps before this fix) — the picture motion
-	// itself needs the *main* input resampled to the target rate so overlay
-	// actually consumes a distinct overlay frame every output frame.
+	// Crops background.mp4 (1280x720) to the viewport, like CSS `cover`. The
+	// portrait path also reshapes the aspect ratio.
+	// The trailing fps filter must run before overlay. The *main* input
+	// ([0:v]) otherwise drives the output cadence, and overlay samples the
+	// picture stream at about 24fps whatever the user picked.
 	const bg: FfmpegFilterChain = {
 		inputs: ["0:v"],
 		steps: [
@@ -322,24 +295,11 @@ function buildFilterComplex(
 
 	if (format !== "gif") return renderFilterComplex([bg, overlay]);
 
-	// GIF has no audio track and needs a palette pass for reasonable
-	// quality (ffmpeg's default GIF encoder without one looks banded/dithered
-	// badly), so its filter graph/map/tail genuinely diverge from mp4/webm
-	// rather than fitting the same fixed shape. paletteuse's default dither
-	// (sierra2_4a, an error-diffusion algorithm) produces essentially random
-	// per-frame noise that both looks worse and compresses worse than an
-	// ordered (Bayer) dither for this kind of content — measured ~29%
-	// smaller (25.4MB -> 18.1MB at 360p/15fps) with no visible quality
-	// difference at bayer_scale=5 (the coarsest/most size-efficient setting)
-	// vs the default. The full 256-color palette (palettegen's default) is
-	// kept as-is — capping max_colors was tried and measured smaller but
-	// caused visible banding, so it was rejected.
-	//
-	// No automatic downscale is applied either (an earlier version silently
-	// halved the composited frame before encoding to keep files small) — the
-	// user asked for real 360p/480p GIF output instead, so full resolution
-	// is used at whatever tier is selected and the client warns with a real
-	// size estimate up front instead of the server quietly shrinking it.
+	// GIF carries no audio and needs a palette pass, so its graph diverges
+	// from the video formats. The Bayer dither measured about 29% smaller
+	// than the sierra2_4a default, with no visible quality loss.
+	// The palette keeps all 256 colors. This code applies no downscale; the
+	// client shows a size estimate instead. See CLAUDE.md.
 	return renderFilterComplex([
 		bg,
 		overlay,
@@ -372,19 +332,15 @@ export async function renderExport(
 	const mapArgs =
 		format === "gif" ? ["-map", "[out]"] : ["-map", "[comp]", "-map", "0:a?"];
 
-	// forces the actual encoded output to our chosen fps — without this,
-	// the muxer just inherits the filter graph's natural framerate (the
-	// *main* input to the overlay filter, i.e. background.mp4's own native
-	// ~23.976fps), silently ignoring whatever fps the rawvideo input above
-	// was piped at. Confirmed by testing: omitting this made every fps
-	// choice other than 24 (background.mp4's own rate, rounded) have no
-	// visible effect at all.
+	// Forces the encoded output to the selected fps. The muxer otherwise
+	// inherits the rate of the filter graph, about 23.976fps, and ignores the
+	// rawvideo input above. Every fps choice except 24 then did nothing.
 	const outputFpsArgs = ["-r", `${fps}`];
 
-	// "-shortest"/"-pix_fmt yuv420p" only make sense for the audio-bearing,
-	// yuv-encoded video formats — gif has neither an audio track to trim nor
-	// a yuv pixel format, and ffmpeg picks the gif muxer from outPath's
-	// extension on its own, same as it already does for mp4/webm
+	// "-shortest" and "-pix_fmt yuv420p" suit the video formats that carry
+	// audio and use YUV. GIF has no audio track to trim. GIF has no YUV pixel
+	// format either. ffmpeg selects the GIF muxer from the extension of
+	// outPath, as it already does for MP4 and WebM.
 	const tailArgs =
 		format === "gif"
 			? []
@@ -424,9 +380,9 @@ export async function renderExport(
 		},
 	);
 
-	// the frame-loop progress above tops out at FRAME_PROGRESS_CAP, not 100 —
-	// this is the real 100%, only reported once ffmpeg has actually finished
-	// (encoding/palette work can run well after the last frame was piped in)
+	// The frame loop above stops at FRAME_PROGRESS_CAP, not at 100. This call
+	// reports the real 100, after ffmpeg finishes. The encode work and the
+	// palette work can run long after the last frame reaches the pipe.
 	onProgress?.(100);
 
 	return outPath;
@@ -446,12 +402,9 @@ type WorkerMessage =
 	| { type: "done"; outputPath: string }
 	| { type: "error"; message: string };
 
-// runs renderExport() on a separate OS thread (server/export-worker.ts)
-// instead of directly on Bun.serve's own thread. @napi-rs/canvas's per-frame
-// drawing is synchronous native CPU work — the ffmpeg subprocess was already
-// off-thread via Bun.spawn, but without this, the *canvas* half of a render
-// would still block the server from handling any other request (page loads,
-// uploads, other exports' progress polls) for the whole render duration.
+// Runs renderExport() on a separate OS thread (server/export-worker.ts). The
+// per-frame drawing of @napi-rs/canvas is synchronous native CPU work, so it
+// would otherwise block every other request for the whole render.
 export function renderExportInWorker(
 	job: ExportJob,
 	onProgress?: (percent: number) => void,
@@ -461,11 +414,9 @@ export function renderExportInWorker(
 			workerData: job,
 		});
 
-		// export-worker.ts has nothing left to do once it posts "done"/
-		// "error", so its own script simply runs to completion and the
-		// thread exits on its own — forcibly worker.terminate()-ing it from
-		// here raced that natural exit and left Bun warning "ObjectRef is
-		// not unref" on every export
+		// export-worker.ts has no work left after it posts a result, so the
+		// thread exits by itself. A forced worker.terminate() raced that
+		// exit and made Bun warn "ObjectRef is not unref" on every export.
 		worker.on("message", (msg: WorkerMessage) => {
 			if (msg.type === "progress") {
 				onProgress?.(msg.percent);
@@ -479,12 +430,9 @@ export function renderExportInWorker(
 	});
 }
 
-// grouped under one name, rather than individually exported, so the
-// module's real public API (renderExport/renderExportInWorker/the format
-// constants above) stays the only thing other files can see — these are
-// pure helpers with no I/O, exposed here purely so tests/keyframes.test.ts
-// can call them directly instead of only exercising them incidentally
-// through a full end-to-end render.
+// One name groups these pure helpers, so the real public API of the module
+// stays visible on its own. They appear here only so tests/keyframes.test.ts
+// can call them directly, instead of through a full render.
 export const testInternals = {
 	travelScale,
 	pictureBox,

--- a/server/keyframes.ts
+++ b/server/keyframes.ts
@@ -1,22 +1,10 @@
-// Hand-ported copy of client/css/stars.css's @keyframes, for the /export
-// route to render frames without a browser (see server/export.ts). This is
-// the canonical animation dataset: scripts/generate-stars-css.ts generates
-// client/css/stars.css *from* this file, so edit here first, then run
-// `just generate-css` (or `bun run generate:css`) to regenerate the CSS —
-// `just check` runs the generator in --check mode and fails if the two
-// files disagree, so drift between them can't go unnoticed the way it did
-// before this generator existed.
+// The canonical animation dataset. scripts/generate-stars-css.ts writes
+// client/css/stars.css from it. Edit here, then run `just generate-css`.
 //
-// A control-point array only lists the CSS keyframe percentages where the
-// source actually specifies that property. Where stars.css omits a
-// property for part of an animation (e.g. spacetwo_3's transform/filter
-// only start at 50%, spacetwo_1's filter only starts at 60%), the browser
-// synthesizes an implicit "identity" value at the 0%/100% boundary and
-// interpolates from there — those synthetic points are written out
-// explicitly below and marked `implicit: true`, so every array already
-// spans 0-100 and the interpolator never needs special-case boundary
-// logic. The generator reads the same flag to know NOT to emit that
-// property at that percentage, since it isn't actually in the source CSS.
+// A control-point array lists only the percentages that stars.css states.
+// A point marked `implicit: true` is a synthetic identity boundary, added so
+// the interpolator can start somewhere. The generator omits those points.
+// See CLAUDE.md for the full reasoning.
 
 type ControlPoint = { percent: number; value: number; implicit?: true };
 
@@ -28,13 +16,10 @@ type FilterControlPoint = {
 	implicit?: true;
 };
 
-// stars.css doesn't use one consistent order for the transform functions:
-// spaceone/dolphins-two write `translate() scale() rotate()`, while
-// spacetwo-*/microone/microtwo write `translate() rotate() scale()` — CSS
-// composes transform functions in written order (the rightmost function
-// applies to the point first), so these produce genuinely different
-// results and server/export.ts's canvas rendering must replicate whichever
-// order the source animation actually uses.
+// stars.css is not consistent here: spaceone and dolphins-two write
+// `translate() scale() rotate()`, the rest `translate() rotate() scale()`.
+// CSS composes in written order, so the two give different results and
+// server/export.ts must follow whichever order an animation uses.
 type TransformOrder = "scale-rotate" | "rotate-scale";
 
 export type PictureAnimation = {
@@ -76,8 +61,8 @@ const filterPts = (
 		implicit ? { percent, kind, amount, implicit } : { percent, kind, amount },
 	);
 
-// spaceone's single-argument `scale(n)` applies uniformly to both axes —
-// shared by scaleX and scaleY below rather than duplicated literally.
+// The single-argument `scale(n)` of spaceone applies to both axes equally.
+// scaleX and scaleY below share this array. The values are not duplicated.
 const spaceoneScale: ControlPoint[] = pts(
 	[0, 2],
 	[5, 1.95],
@@ -205,10 +190,10 @@ export const ANIMATIONS: Record<string, PictureAnimation> = {
 
 	dolphins_1: {
 		durationMs: 4000,
-		// no scale in this animation at all, so scale/rotate order can't
-		// actually be observed — grouped with its rotate-scale sibling
-		// (dolphins_2 uses scale-rotate, so dolphins_1's own written order,
-		// translate/rotate only, doesn't collide with either)
+		// This animation holds no scale, so the order of scale and rotate
+		// cannot show any effect. It groups with its rotate-scale sibling.
+		// dolphins_2 uses scale-rotate. The written order of dolphins_1 is
+		// translate and rotate only, so it collides with neither value.
 		transformOrder: "rotate-scale",
 		x: pts(
 			[0, 1000],
@@ -782,9 +767,9 @@ function interpolateFilter(
 	return { kind, amount };
 }
 
-// elapsedMs is time since the picture's stage became active (not since the
-// whole export started) — matches how stars.css's `infinite` keyframe
-// timelines restart at 0% every time a stage swaps in a fresh class.
+// elapsedMs counts from the moment the stage of the picture became active.
+// It does not count from the start of the export. The `infinite` keyframe
+// timelines in stars.css restart at 0% for each new stage class.
 export function resolvePictureFrame(
 	anim: PictureAnimation,
 	elapsedMs: number,

--- a/server/server.ts
+++ b/server/server.ts
@@ -18,27 +18,23 @@ import {
 	renderExportInWorker,
 } from "./export";
 
-// Fixed on purpose: the app always listens on 9595 inside the container (or
-// on the host, if run directly with `bun server/server.ts`). Only the Docker
-// host-side port mapping is configurable, via APP_PORT in docker-compose.yml.
+// Fixed on purpose. The app always listens on 9595, in a container or on
+// the host. Only the host-side Docker port map changes, through APP_PORT.
 const HTTP_PORT = 9595;
-const HASH_LENGTH = parseInt(process.env.HASH_LENGTH || "5", 10); // hash length for uploaded images URL
-const MAX_HASH_ATTEMPTS = 5; // ponytail: collision odds are ~1e-8 at default HASH_LENGTH; if all attempts collide, proceed and overwrite rather than erroring out
+const HASH_LENGTH = parseInt(process.env.HASH_LENGTH || "5", 10); // Hash length for the URL of an upload.
+// ponytail: collision odds are about 1e-8 at the default HASH_LENGTH. After
+// every attempt collides, the code overwrites instead of raising an error.
+const MAX_HASH_ATTEMPTS = 5;
 
 const uploadsDir = `${import.meta.dir}/../uploads`;
 
-// generous for a cropped/edited PNG out of the browser (the crop zone tops
-// out around 800x700 CSS px, but $toCanvas() renders at source-image
-// resolution, so a large original photo can still produce a large PNG) —
-// just a sane upper bound, not a tight fit
+// A generous upper bound for a cropped PNG from the browser. $toCanvas()
+// renders at the resolution of the source image, not at the crop zone size.
 const MAX_UPLOAD_SIZE = 15 * 1024 * 1024;
 
-// extension to store the upload under, so Bun can infer the right
-// Content-Type when serving it back — the public URL/hash stays bare
-// regardless (see resolveUpload below). New uploads are PNG-only (see
-// '/upload' below, which always re-encodes client-side before sending) —
-// the rest of this map exists purely so uploads from before that
-// restriction still resolve/serve correctly (see KNOWN_SUFFIXES).
+// Extension for the stored file, so Bun can infer the Content-Type on
+// serve. The public hash stays bare. See resolveUpload below. New uploads
+// are PNG only. The other entries keep older uploads readable.
 const EXTENSION_BY_MIME: Record<string, string> = {
 	"image/png": "png",
 	"image/jpeg": "jpg",
@@ -57,9 +53,8 @@ function log(...args: unknown[]) {
 	console.log(`[${new Date().toISOString()}]`, ...args);
 }
 
-// security headers for well-known web vulnerabilities. Not applied to the
-// HTML-bundle routes ('/' and '/*' below) — Bun's HTML-import routing
-// doesn't expose a documented way to attach headers to those.
+// Security headers for well-known web vulnerabilities. The HTML bundle
+// routes '/' and '/*' do not get them. Bun exposes no documented way.
 const securityHeaders = {
 	"X-Content-Type-Options": "nosniff",
 	"X-Frame-Options": "DENY",
@@ -73,11 +68,9 @@ function withSecurityHeaders(response: Response): Response {
 	return response;
 }
 
-// serves a file from `dir`, stripping `prefix` off the request path.
-// Safe against `../` traversal (tested with plain, percent-encoded, and
-// double-encoded variants) because `new URL().pathname` normalizes dot
-// segments per the WHATWG URL spec before we ever slice it — don't replace
-// this with raw `req.url` string matching without re-verifying that.
+// Serves a file from `dir`, stripping `prefix` off the request path.
+// `new URL().pathname` normalizes dot segments before the slice, so a `../`
+// traversal fails. Do not switch to a raw `req.url` match without retesting.
 function serveFrom(dir: string, prefix: string) {
 	return async (req: Request): Promise<Response> => {
 		const url = new URL(req.url);
@@ -90,14 +83,9 @@ function serveFrom(dir: string, prefix: string) {
 	};
 }
 
-// uploads are stored on disk as `<hash>.<ext>` (see '/upload' below) but
-// served from the bare hash, so resolve the real filename by checking the
-// handful of extensions we actually write (plus the bare name, for the
-// unrecognized-MIME-type fallback in '/upload') — a fixed set of direct
-// stats, not a directory scan, so this stays O(1) regardless of how many
-// files are in `uploadsDir`.
-// `HASH_PATTERN` must be checked first: an unvalidated hash could otherwise
-// contain '../' and escape `uploadsDir`.
+// Uploads sit on disk as `<hash>.<ext>` but are served from the bare hash.
+// This loop stats a fixed set of names, so it stays O(1).
+// Check `HASH_PATTERN` first: an unchecked hash could escape `uploadsDir`.
 const HASH_PATTERN = /^[a-zA-Z0-9]+$/;
 const KNOWN_EXTENSIONS = Object.values(EXTENSION_BY_MIME);
 const KNOWN_SUFFIXES = ["", ...KNOWN_EXTENSIONS.map((ext) => `.${ext}`)];
@@ -111,12 +99,9 @@ async function resolveUpload(hash: string): Promise<string | undefined> {
 	return undefined;
 }
 
-// pre-fix uploads were stored bare (no extension), so Bun can't infer their
-// Content-Type on serve — peek at the bytes to at least recognize SVGs,
-// since that's the one format browsers refuse to render inline without the
-// correct header (raster formats already get rendered via the browser's own
-// sniffing regardless of Content-Type). Only called for bare files, which
-// is a fixed, shrinking set — not on every request.
+// Older uploads have no extension, so Bun cannot infer their Content-Type.
+// Only SVG needs the header; a browser sniffs raster formats itself. This
+// runs for bare files only, a fixed and shrinking set.
 const SVG_ROOT_TAG = /<svg[\s>]/i;
 
 async function sniffLegacyContentType(
@@ -131,11 +116,9 @@ async function sniffLegacyContentType(
 
 const dogePath = `${import.meta.dir}/../client/public/img/doge.png`;
 
-// a render is fast now (no headless browser to wait on), but still not
-// free — a single-slot lock is simpler than a real job queue for how
-// rarely concurrent exports will actually happen. exportProgress (0-100)
-// is read by '/export-status' while a render is in flight, so the client
-// can show real progress instead of a bare spinner.
+// A render is fast but not free. A single-slot lock is simpler than a job
+// queue, because two exports rarely overlap. '/export-status' reads
+// exportProgress (0-100) during a render, to show real progress.
 let exportInProgress = false;
 let exportProgress = 0;
 
@@ -156,9 +139,8 @@ function randomHash(length: number): string {
 	return hash;
 }
 
-// generates a random upload hash, retrying on an on-disk name collision —
-// collision odds are ~1e-8 at default HASH_LENGTH (see MAX_HASH_ATTEMPTS
-// above), so a fixed small retry cap is enough
+// Generates a random upload hash. Retries on a name collision on disk.
+// A small fixed retry cap is enough. See MAX_HASH_ATTEMPTS above.
 async function generateUploadHash(): Promise<string> {
 	let hash = "";
 	for (let attempts = 0; attempts < MAX_HASH_ATTEMPTS; attempts++) {
@@ -169,10 +151,9 @@ async function generateUploadHash(): Promise<string> {
 	return hash;
 }
 
-// the 8-byte PNG magic number (see the PNG spec) — checked against the
-// actual uploaded bytes since the client-declared Content-Type can be
-// spoofed by a raw POST, and the stored file is later fed straight into
-// the export renderer's native image decoder
+// The 8-byte PNG magic number. A raw POST can spoof the declared
+// Content-Type, and the export renderer later reads the stored file with a
+// native image decoder, so check the real bytes.
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 async function hasPngSignature(file: Blob): Promise<boolean> {
@@ -208,8 +189,8 @@ function parseExportOptions(searchParams: URLSearchParams): {
 		? (rawFps as FrameRate)
 		: DEFAULT_FPS;
 
-	// enforced server-side too, not just via the client's disabled buttons —
-	// a direct request could otherwise bypass the cap
+	// The server enforces this cap too. The disabled client buttons are not
+	// enough. A direct request could otherwise pass the cap.
 	if (format === "gif") {
 		({ resolution, fps } = clampForGif(resolution, fps));
 	}
@@ -219,20 +200,11 @@ function parseExportOptions(searchParams: URLSearchParams): {
 
 const server = Bun.serve({
 	port: HTTP_PORT,
-	// Bun's default is 10s — too short for '/export/*'. No response bytes
-	// are written until the whole render finishes (a single Response at the
-	// end, not streamed), so the entire render duration counts against this
-	// timeout. Resolution/framerate/format are now configurable, capped at
-	// 720p (background.mp4's own native resolution — no point exporting
-	// larger); measured worst case at 1920x1080@60fps (before that tier was
-	// removed) was ~13s as MP4, ~20s as WebM, so 720p is safely under that.
-	// GIF is separately capped to 480p/24fps (see clampForGif in
-	// server/export.ts — uncapped GIF at 1080p/60fps was measured at ~146s,
-	// dangerously close to a timeout and disproportionate to every other
-	// combination) and was measured at ~13s at that cap (480p/24fps, GIF's
-	// own worst case, produces a ~42MB file — slow/big but still nowhere
-	// near this timeout). 60 leaves several times margin over every real
-	// worst case observed.
+	// The Bun default of 10s is too short for '/export/*'. The server sends
+	// one Response at the end and streams nothing, so the whole render
+	// counts against this timeout. The slowest capped combination measured
+	// about 13s. 60s leaves several times that margin. See CLAUDE.md for the
+	// measured numbers behind the 720p cap and the GIF cap.
 	idleTimeout: 60,
 	routes: {
 		"/": index,
@@ -242,22 +214,18 @@ const server = Bun.serve({
 				const form = await req.formData();
 				const file = form.get("file-upload");
 
-				// PNG-only: the client always crops/re-encodes through canvas
-				// before uploading (needed for the transparency-editing
-				// feature regardless of the original file's format), so
-				// there's no legitimate case where anything else arrives here.
-				// `file.type` is just the client-declared Content-Type on the
-				// multipart part, not a fact about the actual bytes, so it's
-				// only a cheap early-out here — the magic-byte check below is
-				// what actually gates what gets written to disk and later fed
-				// to the export renderer's native image decoder.
+				// PNG only: the client always re-encodes through a canvas
+				// before an upload, so nothing else arrives here
+				// legitimately. `file.type` is only what the client
+				// declares, so this is a cheap early exit. The magic-byte
+				// check below is what gates the disk.
 				if (!(file instanceof Blob) || file.type !== "image/png") {
 					log(
 						"upload rejected: not a PNG",
 						file instanceof Blob ? file.type : typeof file,
 					);
-					// the `error` query param lets the client show a
-					// specific reason instead of just failing silently
+					// The `error` query parameter lets the client show a
+					// specific reason. The upload never fails silently.
 					return withSecurityHeaders(
 						Response.redirect("/?error=invalid_type", 303),
 					);
@@ -302,11 +270,11 @@ const server = Bun.serve({
 			}
 			return withSecurityHeaders(response);
 		},
-		// script.ts references this dynamically at runtime (not statically
-		// analyzable, so the HTML bundler can't pick it up) — serve it directly
+		// script.ts names this path at runtime, as a plain string. The HTML
+		// bundler cannot analyze it, so this route serves the folder.
 		"/img/*": serveFrom(`${import.meta.dir}/../client/public/img`, "/img/"),
-		// the HTML bundler doesn't process <track src> the way it does <source
-		// src> on the same <video>, so the captions file needs its own static route
+		// The HTML bundler processes <source src>. It does not process a
+		// <track src> on the same <video>. The captions need their own route.
 		"/videos/*": serveFrom(
 			`${import.meta.dir}/../client/public/videos`,
 			"/videos/",
@@ -352,9 +320,8 @@ const server = Bun.serve({
 					format,
 					`${bytes.byteLength} bytes`,
 				);
-				// hash-named (or "doge" for the default image) rather than a
-				// fixed "shooting-stars.<ext>" so exporting the same image
-				// twice, or several different ones, don't collide on disk
+				// Named after the hash, or "doge" for the default image. A
+				// fixed name would collide on disk across two exports.
 				const filename = `${hash || "doge"}.${format}`;
 				return withSecurityHeaders(
 					new Response(bytes, {
@@ -375,11 +342,9 @@ const server = Bun.serve({
 			}
 		},
 
-		// polled by the client while an export is in flight (see
-		// client/export.ts) to show real render progress instead of a bare
-		// spinner — a separate top-level path rather than nesting under
-		// '/export/' so it can never collide with that route's wildcard hash
-		// matching (an uploaded image could theoretically hash to "status")
+		// The client polls this during an export, for real progress instead
+		// of a bare spinner. It is a top-level path, not a child of
+		// '/export/', so an upload that hashes to "status" cannot collide.
 		"/export-status": () =>
 			withSecurityHeaders(
 				Response.json({
@@ -388,7 +353,8 @@ const server = Bun.serve({
 				}),
 			),
 
-		// any other path is a client-side-routed uploaded-image hash: serve the same SPA shell
+		// Any other path is an upload hash that the client routes. Serve the
+		// same shell.
 		"/*": index,
 	},
 	error(err) {

--- a/tests/animation-timeline.test.ts
+++ b/tests/animation-timeline.test.ts
@@ -5,10 +5,9 @@ import {
 } from "../client/animation-timeline";
 import { ANIMATIONS } from "../server/keyframes";
 
-// same picture id list as client/animation.ts's `pictures` and
-// server/export.ts's `pictureIds` — not exported from either, so this is a
-// third small literal copy rather than introducing a shared export nobody
-// asked for.
+// The same picture id list as `pictures` in client/animation.ts. It also
+// matches `pictureIds` in server/export.ts. Neither file exports its list.
+// This is therefore a third small copy. A shared export is not necessary.
 const pictureIds = ["pict1", "pict2", "pict3", "pict4", "pict5", "pict6"];
 
 describe("ANIMATION_TIMELINE", () => {

--- a/tests/keyframes.test.ts
+++ b/tests/keyframes.test.ts
@@ -47,8 +47,8 @@ describe("interpolate", () => {
 });
 
 describe("resolvePictureFrame", () => {
-	// mirrors spacetwo_3's shape: transform/filter only declared from 50%,
-	// with an implicit identity point at 0% for the interpolator to start from
+	// Copies the shape of spacetwo_3. The transform and the filter start at
+	// 50%. An implicit identity point at 0% gives the interpolator a start.
 	const anim: PictureAnimation = {
 		durationMs: 1000,
 		transformOrder: "rotate-scale",
@@ -80,17 +80,17 @@ describe("resolvePictureFrame", () => {
 	test("resolves the identity boundary at elapsed=0", () => {
 		const frame = resolvePictureFrame(anim, 0);
 		expect(frame.x).toBe(0);
-		expect(frame.scaleX).toBe(1); // no control points -> identity
+		expect(frame.scaleX).toBe(1); // No control point gives the identity.
 		expect(frame.rotateDeg).toBe(0);
 		expect(frame.opacity).toBe(0);
-		// kind is picked from the first non-"none" point regardless of the
-		// queried percent — only amount is actually interpolated
+		// The kind comes from the first point that is not "none". The queried
+		// percentage does not change it. Only the amount interpolates.
 		expect(frame.filter).toEqual({ kind: "contrast", amount: 1 });
 	});
 
 	test("resolves mid-segment values between two real control points", () => {
 		const frame = resolvePictureFrame(anim, 750);
-		expect(frame.x).toBe(-50); // halfway between 50%(-0) and 100%(-100)
+		expect(frame.x).toBe(-50); // Half way between 50% (-0) and 100% (-100).
 		expect(frame.filter.amount).toBe(3);
 	});
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4,17 +4,15 @@ import server from "../server/server.ts";
 
 const uploadedHashes: string[] = [];
 
-// the real 8-byte PNG magic number, used to build a Blob that passes the
-// server's content-sniffing check regardless of what bytes follow it
+// The real 8-byte PNG magic number, so a test Blob passes the content check
+// of the server whatever bytes follow it.
 const PNG_SIGNATURE = new Uint8Array([
 	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
 ]);
 
-// used by tests that need a real hash to export by, rather than the default
-// doge image — uploads the real doge.png bytes (not a "fake-png-bytes"
-// placeholder like the plain upload tests use) since exporting actually
-// decodes the file through @napi-rs/canvas's loadImage(), which a fake PNG
-// fails. Tracks the upload for cleanup like every other uploadedHashes entry.
+// For tests that need a real hash to export by. It uploads the true doge.png
+// bytes, because an export decodes the file with loadImage() and the
+// placeholder PNG of the plain upload tests fails there.
 async function uploadTestImage(): Promise<string> {
 	const dogeBytes = await Bun.file(
 		`${import.meta.dir}/../client/public/img/doge.png`,
@@ -72,10 +70,9 @@ describe("POST /upload", () => {
 	});
 
 	test("rejects a non-PNG image upload", async () => {
-		// uploads used to accept any image/* type; the client now always
-		// re-encodes to PNG before uploading (needed for the crop/
-		// transparency-editing flow regardless of the source format), so
-		// the server only accepts PNG going forward
+		// Uploads accepted any image/* type before. The client now always
+		// re-encodes to PNG for the crop and transparency steps, so the
+		// server accepts PNG only.
 		const form = new FormData();
 		form.set(
 			"file-upload",
@@ -114,11 +111,12 @@ describe("POST /upload", () => {
 		expect(location).toMatch(/^\/\w{5}$/);
 		uploadedHashes.push(`${location.slice(1)}.png`);
 
-		// the uploaded-hash path serves the same SPA shell as '/'
+		// The upload hash path serves the same shell as '/'.
 		const page = await fetch(new URL(location, server.url));
 		expect(page.status).toBe(200);
 
-		// and the actual uploaded file is stored and served back correctly
+		// The server also stores the uploaded file. It serves it back
+		// correctly.
 		const uploadedFile = await fetch(
 			new URL(`/uploads${location}`, server.url),
 		);
@@ -127,10 +125,9 @@ describe("POST /upload", () => {
 	});
 
 	test("rejects a PNG-typed Blob uploaded under a non-.png filename", async () => {
-		// the server derives the stored type from the filename extension, not
-		// the Blob's own declared `type` — this is why the client always
-		// uploads under a literal `cropped.png` filename rather than the
-		// original file's name, which could carry any extension
+		// The stored type comes from the filename extension, not the declared
+		// `type` of the Blob. This is why the client always uploads under the
+		// literal name `cropped.png`.
 		const form = new FormData();
 		form.set(
 			"file-upload",
@@ -149,9 +146,9 @@ describe("POST /upload", () => {
 	});
 
 	test("rejects a spoofed Content-Type whose bytes aren't actually a PNG", async () => {
-		// a raw client can declare `image/png` on the multipart part
-		// regardless of the real bytes — the server must check the actual
-		// file content, not just trust the declared type
+		// A raw client can declare `image/png` on the multipart part, whatever
+		// the real bytes hold. The server must therefore check the file
+		// content. It must not trust the declared type.
 		const form = new FormData();
 		form.set(
 			"file-upload",
@@ -248,18 +245,18 @@ describe("GET /export/*", () => {
 		expect(res.status).toBe(404);
 	});
 
-	// a real end-to-end render (default doge image, no headless browser
-	// involved — see server/export.ts) rather than mocking ffmpeg/canvas out,
-	// since the whole point of this feature is that this now finishes in a
-	// few seconds instead of the ~25s the old Playwright-based approach took
+	// A real end-to-end render with the default doge image. It mocks out
+	// neither ffmpeg nor the canvas: finishing in seconds, against about 25s
+	// for the old Playwright approach, is the point of the feature.
 	test("renders the default doge animation as a real MP4 export", async () => {
 		const res = await fetch(
 			new URL("/export/?orientation=landscape", server.url),
 		);
 		expect(res.status).toBe(200);
 		expect(res.headers.get("Content-Type")).toBe("video/mp4");
-		// "doge" (not a generic "shooting-stars") since no hash was given —
-		// keeps exports of different images/hashes from overwriting each other
+		// The name is "doge", not a generic "shooting-stars", because the
+		// request gave no hash. Two exports therefore never overwrite each
+		// other on disk.
 		expect(res.headers.get("Content-Disposition")).toBe(
 			'attachment; filename="doge.mp4"',
 		);
@@ -267,9 +264,9 @@ describe("GET /export/*", () => {
 		expect(bytes.byteLength).toBeGreaterThan(1000);
 	}, 30_000);
 
-	// WebM re-encodes both video (VP8) and audio (vorbis, since WebM can't
-	// carry background.mp4's AAC track the way MP4 can) rather than copying,
-	// so it's slower than the MP4 case above — still well inside the timeout
+	// WebM re-encodes video as VP8 and audio as Vorbis, because it cannot
+	// carry the AAC track that MP4 copies. It is therefore slower than the
+	// case above, but still well inside the timeout.
 	test("renders the default doge animation as a real WebM export", async () => {
 		const res = await fetch(
 			new URL("/export/?orientation=landscape&format=webm", server.url),
@@ -299,8 +296,9 @@ describe("GET /export/*", () => {
 		expect(res.headers.get("Content-Type")).toBe("video/mp4");
 	}, 30_000);
 
-	// a smaller-than-default tier (rather than one of the larger/slower ones)
-	// is enough to prove the resolution param is actually threaded through
+	// A tier below the default is enough here. It proves that the server
+	// passes the resolution parameter through. A larger tier only runs
+	// slower.
 	test("renders at a non-default resolution tier", async () => {
 		const res = await fetch(new URL("/export/?resolution=360p", server.url));
 		expect(res.status).toBe(200);
@@ -308,9 +306,8 @@ describe("GET /export/*", () => {
 		expect(bytes.byteLength).toBeGreaterThan(1000);
 	}, 30_000);
 
-	// GIF needs an extra palettegen/paletteuse filter pass (see
-	// server/export.ts) on top of the same compositing work the video
-	// formats do, so it's the slowest of the three — generous timeout
+	// GIF adds a palettegen and paletteuse pass on top of the same
+	// compositing work, so it is the slowest of the three. Generous timeout.
 	test("renders the default doge animation as a real GIF export", async () => {
 		const res = await fetch(
 			new URL("/export/?orientation=landscape&format=gif", server.url),
@@ -324,13 +321,9 @@ describe("GET /export/*", () => {
 		expect(bytes.byteLength).toBeGreaterThan(1000);
 	}, 60_000);
 
-	// GIF at high resolution/framerate was measured at ~146s/~324MB at the
-	// old (now-removed) 1080p/60fps tier vs ~20s/~6MB as WebM at the same
-	// settings — clampForGif() in server/export.ts silently downgrades a GIF
-	// request above 480p/24fps rather than rendering it as requested (GIF
-	// itself excludes the 720p tier entirely), so a request that asks for
-	// 720p/60fps GIF should still come back quickly, not hang for over a
-	// minute
+	// clampForGif() moves a GIF request above 480p24 back down instead of
+	// rendering it as sent. An uncapped GIF at 1080p60 measured about 146s
+	// and 324MB, so a 720p60 request must still come back quickly.
 	test("clamps GIF resolution/fps down from an oversized request", async () => {
 		const start = Date.now();
 		const res = await fetch(
@@ -341,10 +334,9 @@ describe("GET /export/*", () => {
 		expect(Date.now() - start).toBeLessThan(60_000);
 	}, 60_000);
 
-	// covers the hash-based naming path (the "doge" case above only covers
-	// the no-hash fallback) — same filename-building code regardless of
-	// format, so one format is enough to guard against a regression back to
-	// a fixed "shooting-stars.<ext>" name
+	// Covers the hash-based naming path; the "doge" case above covers the
+	// no-hash fallback. One format is enough, since the filename code does
+	// not branch on format.
 	test("uses the upload's hash as the exported filename", async () => {
 		const hash = await uploadTestImage();
 
@@ -357,11 +349,9 @@ describe("GET /export/*", () => {
 		);
 	}, 30_000);
 
-	// exportInProgress is a real single-slot lock (see server/server.ts), not
-	// mocked — firing two renders at once is enough to hit the 429 branch.
-	// Polls /export-status instead of a fixed delay to know the lock is
-	// actually held before firing the second request, so this can't flake
-	// under a slow/fast environment the way a hardcoded sleep could.
+	// exportInProgress is a real single-slot lock, not a mock, so two renders
+	// at once reach the 429 branch. Polling /export-status instead of sleeping
+	// proves the lock is held before the second request goes out.
 	test("rejects a second concurrent export with 429", async () => {
 		const first = fetch(new URL("/export/?orientation=landscape", server.url));
 		while (true) {
@@ -388,7 +378,7 @@ describe("GET /export-status", () => {
 		const exportPromise = fetch(
 			new URL("/export/?orientation=portrait", server.url),
 		);
-		// give the render loop a moment to start producing frames
+		// Gives the render loop time to produce its first frames.
 		await new Promise((resolve) => setTimeout(resolve, 300));
 		const statusRes = await fetch(new URL("/export-status", server.url));
 		const status = await statusRes.json();


### PR DESCRIPTION
## What

Adopt [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/) as the writing standard for this repository, then apply it everywhere.

A new **Writing style** section in `CLAUDE.md` states the rules: 20 words per sentence, one fact per sentence, active voice with a named actor, plain words, no contractions, noun clusters of 3 words or fewer. It applies to code comments, commit messages, documentation, and chat responses. It does not apply to code, file paths, or identifiers.

Every comment in the codebase now follows it. `CLAUDE.md` is rewritten in the same style.

## Comment length

The rule targets **2 to 3 lines per comment**, and asks for the reason rather than the history. Rejected alternatives and measurement logs moved out of the code and into `CLAUDE.md`, with a pointer back from the code.

| | before | after |
|---|---|---|
| longest block | 19 lines | 7 lines |
| blocks of 5+ lines | 41 | 15 |

The three remaining 6-7 line blocks are module headers in `server/keyframes.ts`, `scripts/generate-stars-css.ts`, and `client/export-options.ts`. Each is two short paragraphs.

## CLAUDE.md brought current

The file had drifted from the code. Fixed in the same pass:

- **`randomstring` is gone from the project entirely** and was still documented in two places. `server/server.ts` builds hashes itself, with `randomHash()` over `HASH_CHARS` using `randomInt` from `node:crypto`, retrying up to `MAX_HASH_ATTEMPTS` on collision. The TypeScript section used the package as its module-vs-ambient example, so that paragraph changed too.
- **The upload filter has a third check** that was undocumented: `hasPngSignature()` compares the first 8 bytes against the PNG magic number. It is the real gate, since `file.type` is client-declared and a raw `POST` can spoof it.
- **GIF export plus the `resolution` and `fps` query parameters** were missing. The `/export/*` bullet is now five bullets covering `parseExportOptions()`, the three formats, the GIF caps via `clampForGif()`, the `idleTimeout` and 429 lock and `Content-Disposition` naming, and the worker thread.
- **Three modules had no bullet at all**: `client/export.ts`, `client/export-options.ts`, `client/volume.ts`.
- **The preview dialog has a source step** — drag and drop, paste, browse — that was undocumented, including the two-media-query `isMobile` test that `client/export.ts` reuses.
- Smaller gaps: `just test-coverage`, `just clean`, the `package.json` scripts, `resolveJsonModule`, the `#quick-actions` dock and three dialogs in `index.html`, the copy-link and version-footer work in `script.ts`, the export dialogs in `dialog.css`, the `bun` healthcheck, the `scripts/` bind mount, and separate bullets for `keyframes.test.ts` and `animation-timeline.test.ts`.

## Risk

**No executable code changes.** Every changed line is a comment, a comment continuation line, or `CLAUDE.md` prose. Verified by filtering the diff for non-comment lines.

## Verification

- `just check` passes: `tsc --noEmit`, `biome check`, and the `stars.css` freshness check.
- `just test` passes: 49 tests, 0 failures.
- `docker compose config` validates.
- `just --list` still renders the recipe help correctly, which the justfile comment rewrites could have broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Standardize comments and documentation on ASD-STE100 Simplified Technical English, update CLAUDE.md to match current architecture and behavior, and refine supporting scripts, tests, and configs without changing executable code.

Enhancements:
- Shorten, clarify, and align code comments across server, client, tests, Dockerfiles, scripts, and CSS with the new writing style while preserving behavior.
- Improve explanation and naming consistency for export options, GIF limits, progress reporting, and worker-based rendering across server and client modules.
- Document previously under-described modules and flows such as export options, volume control, preview dialog steps, animation timeline, upload retention, and healthchecks.

Build:
- Clarify Dockerfile stages, dependency separation, and environment assumptions with updated comments, maintaining the existing build pipeline.

Deployment:
- Clarify docker-compose configuration, especially UPLOADS_DIR defaults, healthcheck behavior, and service roles via updated comments.

Documentation:
- Rewrite CLAUDE.md to describe project architecture, commands, configuration, export behavior, and writing style using ASD-STE100, including the new Simplified Technical English rules and updated feature coverage.

Tests:
- Refine test descriptions and inline comments in server and keyframes related test files to reflect the current behavior and constraints of uploads and exports.

Chores:
- Update justfile and scripts/generate-stars-css.sh comments to reflect current usage and checks, aligning recipe descriptions with the new documentation style.